### PR TITLE
Fixed JSON response handling, implemented _handle_water_level, changed batterystatus

### DIFF
--- a/example/app2.js
+++ b/example/app2.js
@@ -33,7 +33,7 @@ api.connect(email, password_hash).then(() => {
                 console.log('[app2.js] CleanReport: ' + state);
             });
             vacbot.on('BatteryInfo', (batterystatus) => {
-                let battery = Math.round(batterystatus * 100);
+                let battery = Math.round(batterystatus);
                 console.log('[app2.js] BatteryInfo: ' + battery);
             });
             vacbot.on('LifeSpan_filter', (level) => {

--- a/index.js
+++ b/index.js
@@ -596,21 +596,27 @@ class VacBot {
     if (event.hasOwnProperty('body')) {
       value = event['body']['data']['value'];
     } else if (event.hasOwnProperty('ctl')) {
-      value = event['ctl']['battery']['power'];
+      value = event['ctl']['battery']['power']*100;
     } else {
-      value = parseFloat(event.attrs['power']) / 100;
+      value = parseFloat(event.attrs['power']);
     }
     try {
       this.battery_status = value;
-      tools.envLog("[VacBot] *** battery_status = %d\%", this.battery_status * 100);
+      tools.envLog("[VacBot] *** battery_status = %d\%", this.battery_status);
     } catch (e) {
       console.error("[VacBot] couldn't parse battery status ", event);
     }
   }
 
-  _handle_water_level(level) {
-      this.water_level = level;
-      tools.envLog("[VacBot] *** water_level = " + constants.WATER_LEVEL_FROM_ECOVACS[level] + " (" + level + ")");
+  _handle_water_level(event) {
+
+    // Deebot Ozmo 950
+    if (event.hasOwnProperty('body')) {
+      this.water_level = event['body']['data']['amount'];
+    } else {
+      this.water_level = event.attrs['level']; //TODO Please check for non 950 models
+    }
+    tools.envLog("[VacBot] *** water_level = " + constants.WATER_LEVEL_FROM_ECOVACS[this.water_level] + " (" + this.water_level + ")");
   }
 
   _handle_waterbox_info(val) {

--- a/library/ecovacsMQTT.js
+++ b/library/ecovacsMQTT.js
@@ -205,11 +205,11 @@ class EcovacsMQTT extends EventEmitter {
             const req = https.request(reqOptions, (res) => {
                 res.setEncoding('utf8');
                 res.setTimeout(6000);
-                tools.envLog("[EcovacsMQTT] (request statusCode:", res.statusCode);
-                tools.envLog("[EcovacsMQTT] (request statusMessage:", res.statusMessage);
-                tools.envLog("[EcovacsMQTT] (request url:", res.url);
-                tools.envLog("[EcovacsMQTT] (request urlPathArgs:", res.urlPathArgs);
-                tools.envLog("[EcovacsMQTT] (request headers:", res.headers);
+                // tools.envLog("[EcovacsMQTT] (request statusCode:", res.statusCode);
+                // tools.envLog("[EcovacsMQTT] (request statusMessage:", res.statusMessage);
+                // tools.envLog("[EcovacsMQTT] (request url:", res.url);
+                // tools.envLog("[EcovacsMQTT] (request urlPathArgs:", res.urlPathArgs);
+                // tools.envLog("[EcovacsMQTT] (request headers:", res.headers);
                 let rawData = '';
                 res.on('data', (chunk) => {
                     rawData += chunk;
@@ -280,10 +280,8 @@ class EcovacsMQTT extends EventEmitter {
             tools.envLog("[EcovacsMQTT] _command_to_dict_api() xmlOrJson missing ... action: %s", action);
             return result;
         }
-        if (tools.isValidJsonString(xmlOrJson) || this.bot.isOzmo950()) {
-            tools.envLog("[EcovacsMQTT] _command_to_dict_api() isValidJsonString: %s", tools.isValidJsonString(xmlOrJson));
-            tools.envLog("[EcovacsMQTT] _command_to_dict_api() isOzmo950: %s", this.bot.isOzmo950());
-            let result = JSON.parse(xmlOrJson);
+        if (tools.isValidJsonString(JSON.stringify(xmlOrJson, getCircularReplacer()))) {
+            let result = xmlOrJson;
             if (result.hasOwnProperty('body')) {
                 if (result['body']['msg'] === 'ok') {
                     result['event'] = tools.getEventNameForCommandString(action.name);
@@ -460,6 +458,9 @@ class EcovacsMQTT extends EventEmitter {
                 break;
             case "DeebotPosition":
                 this.bot._handle_deebot_position(event);
+                break;
+            case "WaterLevel":
+                this.bot._handle_water_level(event);
                 break;
             default:
                 tools.envLog("[EcovacsMQTT] Unknown command received: %s", command);

--- a/library/ecovacsMQTT.js
+++ b/library/ecovacsMQTT.js
@@ -252,7 +252,7 @@ class EcovacsMQTT extends EventEmitter {
         if (message) {
             tools.envLog("[EcovacsMQTT] _handle_command_response() message: %s", JSON.stringify(message, getCircularReplacer()));
             if (message.hasOwnProperty('resp')) {
-
+                tools.envLog("[EcovacsMQTT] _handle_command_response() resp(0): %s", command, JSON.stringify(resp, getCircularReplacer()));
                 resp = this._command_to_dict_api(action, message['resp']);
                 tools.envLog("[EcovacsMQTT] _handle_command_response() resp(1): %s", command, JSON.stringify(resp, getCircularReplacer()));
             }
@@ -275,7 +275,9 @@ class EcovacsMQTT extends EventEmitter {
             tools.envLog("[EcovacsMQTT] _command_to_dict_api() xmlOrJson missing ... action: %s", action);
             return result;
         }
-        if (tools.isValidJsonString(xmlOrJson)) {
+        if (tools.isValidJsonString(xmlOrJson) || this.bot.isOzmo950()) {
+            tools.envLog("[EcovacsMQTT] _command_to_dict_api() isValidJsonString: %s", tools.isValidJsonString(xmlOrJson));
+            tools.envLog("[EcovacsMQTT] _command_to_dict_api() isOzmo950: %s", this.bot.isOzmo950());
             let result = JSON.parse(xmlOrJson);
             if (result.hasOwnProperty('body')) {
                 if (result['body']['msg'] === 'ok') {
@@ -285,6 +287,7 @@ class EcovacsMQTT extends EventEmitter {
             return result;
         }
         else {
+            tools.envLog("[EcovacsMQTT] _command_to_dict_api() isValidJsonString false: %s");
             let xmlString = xmlOrJson;
             let payloadXml = new DOMParser().parseFromString(xmlString, 'text/xml');
             if (payloadXml.documentElement.hasChildNodes()) {

--- a/library/tools.js
+++ b/library/tools.js
@@ -20,21 +20,25 @@ function isValidJsonString(str) {
 
 function getEventNameForCommandString(str) {
     envLog("[tools] getEventNameForCommandString() str: %s", str);
-    let command = str.replace(/^_+|_+$/g, '').replace('Get','').replace("Server", "");
+    let command = str.toLowerCase().replace(/^_+|_+$/g, '').replace("get","").replace("server", "");
+    envLog("[tools] getEventNameForCommandString() command: %s", command);
     switch (command.toLowerCase()) {
         case 'clean':
         case 'cleanreport':
+        case 'cleaninfo':
             return 'CleanReport';
         case 'charge':
         case 'chargestate':
             return 'ChargeState';
         case "battery":
         case 'batteryinfo':
+        case 'battery':
             return 'BatteryInfo';
         case 'lifespan':
             return 'LifeSpan';
         case "waterlevel":
         case "waterpermeability":
+        case "waterinfo":
             return 'WaterLevel';
         case "waterboxinfo":
             return 'WaterBoxInfo';

--- a/library/tools.js
+++ b/library/tools.js
@@ -8,10 +8,13 @@ function isObject(val) {
 
 function isValidJsonString(str) {
     try {
+        envLog("[tools] isValidJsonString() str: %s", str);
         JSON.parse(str);
     } catch (e) {
+        envLog("[tools] isValidJsonString() false");
         return false;
     }
+    envLog("[tools] isValidJsonString() true");
     return true;
 }
 

--- a/library/vacBotCommand.js
+++ b/library/vacBotCommand.js
@@ -47,7 +47,7 @@ class Clean extends VacBotCommand {
             }
         }
         tools.envLog('initCmd %s', initCmd);
-        super('Clean', {
+        super('clean', {
             'clean': initCmd
         })
     }
@@ -106,7 +106,7 @@ class CustomArea extends Clean {
 
 class Charge extends VacBotCommand {
     constructor() {
-        super('Charge', {
+        super('charge', {
             'charge': {
                 'type': constants.CHARGE_MODE_TO_ECOVACS['return']
             }
@@ -116,31 +116,31 @@ class Charge extends VacBotCommand {
 
 class GetDeviceInfo extends VacBotCommand {
     constructor() {
-        super('GetDeviceInfo');
+        super('getDeviceInfo');
     }
 }
 
 class GetCleanState extends VacBotCommand {
     constructor() {
-        super('GetCleanState');
+        super('getCleanState');
     }
 }
 
 class GetChargeState extends VacBotCommand {
     constructor() {
-        super('GetChargeState');
+        super('getChargeState');
     }
 }
 
 class GetBatteryState extends VacBotCommand {
     constructor() {
-        super('GetBatteryInfo');
+        super('getBatteryInfo');
     }
 }
 
 class GetLifeSpan extends VacBotCommand {
     constructor(component) {
-        super('GetLifeSpan', {
+        super('getLifeSpan', {
             'type': constants.COMPONENT_TO_ECOVACS[component]
         });
     }
@@ -159,7 +159,7 @@ class SetTime extends VacBotCommand {
 
 class GetCleanSpeed extends VacBotCommand {
     constructor(component) {
-        super('GetCleanSpeed');
+        super('getCleanSpeed');
     }
 }
 
@@ -176,25 +176,25 @@ class SetWaterLevel extends VacBotCommand {
 
 class GetWaterLevel extends VacBotCommand {
     constructor() {
-        super('GetWaterPermeability');
+        super('getWaterPermeability');
     }
 }
 
 class GetWaterBoxInfo extends VacBotCommand {
     constructor() {
-        super('GetWaterBoxInfo');
+        super('getWaterBoxInfo');
     }
 }
 
 class GetDeebotPos extends VacBotCommand {
     constructor() {
-        super('GetDeebotPos');
+        super('getDeebotPos');
     }
 }
 
 class PlaySound extends VacBotCommand {
     constructor(sid = '0') {
-        super('PlaySound', {'count': 1, 'sid': sid});
+        super('playSound', {'count': 1, 'sid': sid});
     }
 }
 

--- a/library/vacBotCommand.js
+++ b/library/vacBotCommand.js
@@ -47,7 +47,7 @@ class Clean extends VacBotCommand {
             }
         }
         tools.envLog('initCmd %s', initCmd);
-        super('clean', {
+        super('Clean', {
             'clean': initCmd
         })
     }
@@ -106,7 +106,7 @@ class CustomArea extends Clean {
 
 class Charge extends VacBotCommand {
     constructor() {
-        super('charge', {
+        super('Charge', {
             'charge': {
                 'type': constants.CHARGE_MODE_TO_ECOVACS['return']
             }
@@ -116,31 +116,31 @@ class Charge extends VacBotCommand {
 
 class GetDeviceInfo extends VacBotCommand {
     constructor() {
-        super('getDeviceInfo');
+        super('GetDeviceInfo');
     }
 }
 
 class GetCleanState extends VacBotCommand {
     constructor() {
-        super('getCleanState');
+        super('GetCleanState');
     }
 }
 
 class GetChargeState extends VacBotCommand {
     constructor() {
-        super('getChargeState');
+        super('GetChargeState');
     }
 }
 
 class GetBatteryState extends VacBotCommand {
     constructor() {
-        super('getBatteryInfo');
+        super('GetBatteryInfo');
     }
 }
 
 class GetLifeSpan extends VacBotCommand {
     constructor(component) {
-        super('getLifeSpan', {
+        super('GetLifeSpan', {
             'type': constants.COMPONENT_TO_ECOVACS[component]
         });
     }
@@ -159,7 +159,7 @@ class SetTime extends VacBotCommand {
 
 class GetCleanSpeed extends VacBotCommand {
     constructor(component) {
-        super('getCleanSpeed');
+        super('GetCleanSpeed');
     }
 }
 
@@ -176,25 +176,25 @@ class SetWaterLevel extends VacBotCommand {
 
 class GetWaterLevel extends VacBotCommand {
     constructor() {
-        super('getWaterPermeability');
+        super('GetWaterPermeability');
     }
 }
 
 class GetWaterBoxInfo extends VacBotCommand {
     constructor() {
-        super('getWaterBoxInfo');
+        super('GetWaterBoxInfo');
     }
 }
 
 class GetDeebotPos extends VacBotCommand {
     constructor() {
-        super('getDeebotPos');
+        super('GetDeebotPos');
     }
 }
 
 class PlaySound extends VacBotCommand {
     constructor(sid = '0') {
-        super('playSound', {'count': 1, 'sid': sid});
+        super('PlaySound', {'count': 1, 'sid': sid});
     }
 }
 


### PR DESCRIPTION
Am wichtigsten: 
Im EcovacsMQTT._command_to_dict_api habe ich die isValidJson-Abfrage korrigiert, nun kommen auch für den 950 die Antworten korrekt durch.
In der Funktion _message_to_dict funktioniert es auch weiterhin (ohne Änderung von mir)

Zusätzlich:
- der commit "revert commands" ist nur um meine testweise Änderungen an den Kommandos (camelCase) wieder rückgängig zu machen.
- Ich hab batterystatus auf 0-100 normiert (war vorher auf 0-1?), ich hoffe das passt so (oder war das für den ioBroker?) sonst gerne wieder umkehren, der 950 liefert "100" zurück.
- Ich hab das _handle_water_level im _handle_command eingefügt und im VacBot die Funktion geändert (hat das vorher mit den nicht-950ern funktioniert? war ja nicht vollständig implementiert, oder? Teste bitte mal, ob die Abfrage auf event.attrs['level'] richtig ist. War nur geraten...)