### PR TITLE
Improved 950 send commands

### DIFF
--- a/index.js
+++ b/index.js
@@ -757,6 +757,9 @@ class VacBot {
         case "pause":
           this.send_command(new vacBotCommand950.Pause());
           break;
+        case "resume":
+          this.send_command(new vacBotCommand950.Resume());
+          break;
         case "charge":
           this.send_command(new vacBotCommand950.Charge());
           break;
@@ -792,19 +795,19 @@ class VacBot {
           if (this.isOzmo950()) {
             component = constants.COMPONENT_TO_OZMO950[component];
           }
-          this.send_command(new vacBotCommand.GetLifeSpan(component));
+          this.send_command(new vacBotCommand950.GetLifeSpan(component));
           break;
         case "getwaterlevel":
-          this.send_command(new vacBotCommand.GetWaterLevel());
+          this.send_command(new vacBotCommand950.GetWaterLevel());
           break;
         case "setwaterlevel":
           if (arguments.length < 2) {
             return;
           }
-          this.send_command(new vacBotCommand.SetWaterLevel(arguments[1]));
+          this.send_command(new vacBotCommand950.SetWaterLevel(arguments[1]));
           break;
         case "getwaterboxinfo":
-          this.send_command(new vacBotCommand.GetWaterBoxInfo());
+          this.send_command(new vacBotCommand950.GetWaterBoxInfo());
           break;
       }
     }

--- a/library/ecovacsConstants.js
+++ b/library/ecovacsConstants.js
@@ -21,11 +21,12 @@ exports.CLEAN_MODE_TO_ECOVACS = {
 };
 exports.CLEAN_MODE_TO_OZMO950 = {
     'auto': 'auto',
-    'edge': 'border',
+    'edge': 'edge',
     'spot': 'spot',
-    'spot_area': 'spotArea',
+    'spotArea': 'spotArea',
     'single_room': 'singleroom',
-    'stop': 'stop'
+    'stop': 'stop',
+    'customArea': 'customArea',
 };
 
 
@@ -96,7 +97,7 @@ exports.CHARGE_MODE_TO_ECOVACS = {
     'idle': 'Idle'
 };
 exports.CHARGE_MODE_TO_OZMO950 = {
-    'return': 'return',
+    'return': 'go',
     'returning': 'returning',
     'charging': 'charging',
     'idle': 'idle'
@@ -143,7 +144,7 @@ exports.COMMAND_TO_OZMO950 = {
     'GetChargeState': 'getChargeState',
     'GetWaterBoxInfo': 'getWaterInfo',
     'GetWaterPermeability': 'getWaterInfo',
-    'SetWaterPermeability': 'setWaterPermeability'
+    'SetWaterPermeability': 'setWaterInfo'
 };
 
 exports.SupportedDevices = {

--- a/library/ecovacsMQTT.js
+++ b/library/ecovacsMQTT.js
@@ -365,7 +365,7 @@ class EcovacsMQTT extends EventEmitter {
     _message_to_dict(topic, xmlOrJson) {
         // TODO: fix duplicate code
         let name = null;
-        tools.envLog("[EcovacsMQTT] _message_to_dict topic: %s", topic);
+        tools.envLog("[EcovacsMQTT] _message_to_dict topic: %s", topic.name, " ", topic);
         if (!xmlOrJson) {
             tools.envLog("[EcovacsMQTT] _message_to_dict xmlOrJson missing ... topic: %s", topic);
             return {};
@@ -375,6 +375,7 @@ class EcovacsMQTT extends EventEmitter {
             if (xmlOrJson.hasOwnProperty('body')) {
                 tools.envLog("[EcovacsMQTT] _message_to_dict body: %s", JSON.stringify(result['body'], getCircularReplacer()));
                 if (result['body']['msg'] === 'ok') {
+                    tools.envLog("[EcovacsMQTT] _message_to_dict [1]]");
                     result['event'] = tools.getEventNameForCommandString(topic.name);
                     if (!result['event']) {
                         //Default back to replacing Get from the api cmdName
@@ -382,6 +383,7 @@ class EcovacsMQTT extends EventEmitter {
                         result['event'] = topic.name;
                     }
                 } else if (result['body']['data']) {
+                    tools.envLog("[EcovacsMQTT] _message_to_dict [2]]");
                     let data = result['body']['data'];
                     if ((data.hasOwnProperty('cleanState'))) {
                         if (data['cleanstate']['type']) {
@@ -389,6 +391,7 @@ class EcovacsMQTT extends EventEmitter {
                         }
                     }
                 } else {
+                    tools.envLog("[EcovacsMQTT] _message_to_dict [3]]");
                     if (result['body']['msg'] === 'fail') {
                         if (name === "charge") {
                             result['event'] = "ChargeState";
@@ -399,6 +402,7 @@ class EcovacsMQTT extends EventEmitter {
                     }
                 }
             }
+            tools.envLog("[EcovacsMQTT] _message_to_dict result.event: %s", result.event);
             return result;
         }
         else {

--- a/library/vacBotCommand950.js
+++ b/library/vacBotCommand950.js
@@ -64,32 +64,41 @@ function getReqID(customid = '0') {
 
 class Edge extends Clean {
     constructor() {
-        super('edge');
+        super('edge', 'start');
     }
 }
 
 class Spot extends Clean {
     constructor() {
-        super('spot');
+        super('spot', 'start'
+        //, {'content':'-291,111'}
+        ); 
+        // requires content, not included to not start the bot without knowing what happens
     }
 }
 
 class Pause extends VacBotCommand950 {
     constructor() {
-        super('pause', {'act': 'pause'});
+        super('clean', {'act': 'pause'});
+    }
+}
+
+class Resume extends VacBotCommand950 {
+    constructor() {
+        super('clean', {'act': 'resume'});
     }
 }
 
 class Stop extends VacBotCommand950 {
     constructor() {
-        super('stop',  {'act': 'stop'});
+        super('clean',  {'act': 'stop'});
     }
 }
 
 class SpotArea extends Clean {
     constructor(action = 'start', area = '') {
         if (area !== '') {
-            super('spot_area', action, {'mid': area});
+            super('spotArea', action, {'content': area, 'count': '1'});
         }
     }
 }
@@ -97,7 +106,7 @@ class SpotArea extends Clean {
 class CustomArea extends Clean {
     constructor(action = 'start', map_position = '', cleanings = 1) {
         if (map_position !== '') {
-            super('spot_area', action, {'p': map_position, 'deep': cleanings});
+            super('customArea', action, {'content': map_position, 'count': cleanings});
         }
     }
 }
@@ -162,7 +171,7 @@ class SetWaterLevel extends VacBotCommand950 {
             level = constants.WATER_LEVEL_TO_ECOVACS[level];
         }
         super('SetWaterPermeability', {
-            'v': level
+            'amount': level
         });
     }
 }
@@ -198,6 +207,7 @@ module.exports.SpotArea = SpotArea;
 module.exports.CustomArea = CustomArea;
 module.exports.Stop = Stop;
 module.exports.Pause = Pause;
+module.exports.Resume = Resume;
 module.exports.Charge = Charge;
 module.exports.GetDeebotPos = GetDeebotPos;
 module.exports.GetDeviceInfo = GetDeviceInfo;


### PR DESCRIPTION
For iBroker-Adapter Readme:

### Buttons and control
| model | basic * | pause | spot | spotArea | customArea ** | edge | playSound | waterLevel |
|------ |------ |------ |------ |------ |------ |------ |------ |------ |
| Deebot Ozmo 950 | x  | x | (available but parameters required, not implemented) | x | x | n/a | x | x |

### Info and status
| model | battery | chargestatus | cleanstatus | waterLevel | consumables |
|------ |------ |------ |------ |------|------ |
| Deebot Ozmo 950 | x | not working | x | not working | not working |

Zusätzlich hab ich noch ein zusätzliches logging für die MQTT topics eingefügt