### PR TITLE
GetPosition, GetCleanSpeed, relocate

### DIFF
--- a/library/ecovacsConstants_950type.js
+++ b/library/ecovacsConstants_950type.js
@@ -88,18 +88,4 @@ exports.COMPONENT_FROM_ECOVACS = {
     'heap': 'filter'
 };
 
-exports.COMMAND_TO_ECOVACS = {
-    'Clean': 'clean',
-    'Charge': 'charge',
-    'SetTime': 'setTime',
-    'PlaySound': 'playSound',
-    'GetLifeSpan': 'getLifeSpan',
-    'GetBatteryInfo': 'getBattery',
-    'GetCleanState': 'getCleanInfo',
-    'GetCleanSpeed': 'getCleanSpeed',
-    'GetChargeState': 'getChargeState',
-    'GetWaterInfo': 'getWaterInfo',
-    'GetWaterBoxInfo': 'getWaterInfo',
-    'GetWaterPermeability': 'getWaterInfo',
-    'SetWaterPermeability': 'setWaterInfo'
-};
+

--- a/library/ecovacsConstants_950type.js
+++ b/library/ecovacsConstants_950type.js
@@ -98,6 +98,7 @@ exports.COMMAND_TO_ECOVACS = {
     'GetCleanState': 'getCleanInfo',
     'GetCleanSpeed': 'getCleanSpeed',
     'GetChargeState': 'getChargeState',
+    'GetWaterInfo': 'getWaterInfo',
     'GetWaterBoxInfo': 'getWaterInfo',
     'GetWaterPermeability': 'getWaterInfo',
     'SetWaterPermeability': 'setWaterInfo'

--- a/library/ecovacsMQTT_JSON.js
+++ b/library/ecovacsMQTT_JSON.js
@@ -281,20 +281,27 @@ class EcovacsMQTT_JSON extends EventEmitter {
 
     _handle_command(command, event) {
         tools.envLog("[EcovacsMQTT_JSON] _handle_command() command %s received event: %s", command, JSON.stringify(event, getCircularReplacer()));
-        switch (tools.getEventNameForCommandString(command)) {
-            case "ChargeState":
+        command = command.toLowerCase().replace(/^_+|_+$/g, '');
+        if(command.startsWith("on")) { //incoming events
+            command = command.substring(2);
+        }
+        if(command.startsWith("get")) { //remove from "get" commands
+            command = command.substring(3);
+        }
+        switch (command) {
+            case "chargestate":
                 this.bot._handle_charge_state(event);
                 this.emit("ChargeState", this.bot.charge_status);
                 break;
-            case "BatteryInfo":
+            case "batteryinfo":
                 this.bot._handle_battery_info(event);
                 this.emit("BatteryInfo", this.bot.battery_status);
                 break;
             case "cleaninfo":
-                this.bot._handle_clean_report(event);
+                this.bot._handle_clean_info(event);
                 this.emit("CleanReport", this.bot.clean_status);
                 break;
-            case "LifeSpan":
+            case "lifespan":
                 this.bot._handle_life_span(event);
                 if(this.bot.components["filter"]) {
                     this.emit("LifeSpan_filter", this.bot.components["filter"]);
@@ -306,11 +313,11 @@ class EcovacsMQTT_JSON extends EventEmitter {
                     this.emit("LifeSpan_main_brush", this.bot.components["main_brush"]);
                 }
                 break;
-            case "DeebotPosition":
-                this.bot._handle_deebot_position(event);
+            case "pos":
+                this.bot._handle_position(event);
                 break;
-            case "WaterLevel":
-                this.bot._handle_water_level(event);
+            case "waterinfo":
+                this.bot._handle_water_info(event);
                 break;
             default:
                 tools.envLog("[EcovacsMQTT_JSON] Unknown command received: %s", command);

--- a/library/ecovacsMQTT_JSON.js
+++ b/library/ecovacsMQTT_JSON.js
@@ -93,8 +93,6 @@ class EcovacsMQTT_JSON extends EventEmitter {
     }
 
     send_command(action, recipient) {
-        action.name = dictionary.COMMAND_TO_ECOVACS[action.name];
-
         let c = this._wrap_command(action, recipient);
         tools.envLog("[EcovacsMQTT_JSON] c: %s", JSON.stringify(c, getCircularReplacer()));
         this._call_ecovacs_device_api(c).then((json) => {
@@ -285,7 +283,7 @@ class EcovacsMQTT_JSON extends EventEmitter {
         if(command.startsWith("on")) { //incoming events
             command = command.substring(2);
         }
-        if(command.startsWith("get")) { //remove from "get" commands
+        if(command.startsWith("get") ) { //remove from "get" commands
             command = command.substring(3);
         }
         switch (command) {
@@ -293,13 +291,23 @@ class EcovacsMQTT_JSON extends EventEmitter {
                 this.bot._handle_charge_state(event);
                 this.emit("ChargeState", this.bot.charge_status);
                 break;
+            case "battery":
             case "batteryinfo":
                 this.bot._handle_battery_info(event);
                 this.emit("BatteryInfo", this.bot.battery_status);
                 break;
             case "cleaninfo":
                 this.bot._handle_clean_info(event);
-                this.emit("CleanReport", this.bot.clean_status);
+                this.emit("CleanState", this.bot.clean_status);
+                break;
+            case "cleanspeed":
+            case "speed":
+                this.bot._handle_clean_speed(event);
+                this.emit("FanSpeed", this.bot.fan_speed);
+                break;
+            case "relocationstate":
+                this.bot._handle_relocationState(event);
+                this.emit("RelocationState", this.bot.relocation_state);
                 break;
             case "lifespan":
                 this.bot._handle_life_span(event);
@@ -315,9 +323,13 @@ class EcovacsMQTT_JSON extends EventEmitter {
                 break;
             case "pos":
                 this.bot._handle_position(event);
+                this.emit("DeebotPosition", this.bot.deebot_position["x"]+","+this.bot.deebot_position["y"]+","+this.bot.deebot_position["a"]);
+                this.emit("ChargePosition", this.bot.charge_position["x"]+","+this.bot.charge_position["y"]+","+this.bot.charge_position["a"]);
                 break;
             case "waterinfo":
                 this.bot._handle_water_info(event);
+                this.emit("WaterBoxInfo", this.bot.waterbox_info);
+                this.emit("WaterLevel", this.bot.water_level);
                 break;
             default:
                 tools.envLog("[EcovacsMQTT_JSON] Unknown command received: %s", command);

--- a/library/vacBotCommand_950type.js
+++ b/library/vacBotCommand_950type.js
@@ -155,15 +155,9 @@ class SetWaterLevel extends VacBotCommand_950type {
     }
 }
 
-class GetWaterLevel extends VacBotCommand_950type {
+class GetWaterInfo extends VacBotCommand_950type {
     constructor() {
-        super('GetWaterPermeability');
-    }
-}
-
-class GetWaterBoxInfo extends VacBotCommand_950type {
-    constructor() {
-        super('GetWaterBoxInfo');
+        super('GetWaterInfo');
     }
 }
 
@@ -196,7 +190,6 @@ module.exports.GetBatteryState = GetBatteryState;
 module.exports.GetLifeSpan = GetLifeSpan;
 module.exports.SetTime = SetTime;
 module.exports.GetCleanSpeed = GetCleanSpeed;
-module.exports.GetWaterLevel = GetWaterLevel;
+module.exports.GetWaterInfo = GetWaterInfo;
 module.exports.SetWaterLevel = SetWaterLevel;
-module.exports.GetWaterBoxInfo = GetWaterBoxInfo;
 module.exports.PlaySound = PlaySound;

--- a/library/vacBotCommand_950type.js
+++ b/library/vacBotCommand_950type.js
@@ -29,7 +29,7 @@ class Clean extends VacBotCommand_950type {
             }
         }
         tools.envLog('initCmd %s', initCmd);
-        super('Clean', initCmd);
+        super('clean', initCmd);
     }
 }
 
@@ -58,19 +58,19 @@ class Spot extends Clean {
 
 class Pause extends VacBotCommand_950type {
     constructor() {
-        super('Clean', {'act': 'pause'});
+        super('clean', {'act': 'pause'});
     }
 }
 
 class Resume extends VacBotCommand_950type {
     constructor() {
-        super('Clean', {'act': 'resume'});
+        super('clean', {'act': 'resume'});
     }
 }
 
 class Stop extends VacBotCommand_950type {
     constructor() {
-        super('Clean',  {'act': 'stop'});
+        super('clean',  {'act': 'stop'});
     }
 }
 
@@ -92,44 +92,50 @@ class CustomArea extends Clean {
 
 class Charge extends VacBotCommand_950type {
     constructor() {
-        super('Charge', {'act': constants_type.CHARGE_MODE_TO_ECOVACS['return']}
+        super('charge', {'act': constants_type.CHARGE_MODE_TO_ECOVACS['return']}
         );
     }
 }
 
 class GetDeviceInfo extends VacBotCommand_950type {
     constructor() {
-        super('GetDeviceInfo');
+        super('getDeviceInfo');
+    }
+}
+
+class Relocate extends VacBotCommand_950type {
+    constructor() {
+        super('setRelocationState', { "mode": "manu" });
     }
 }
 
 class GetCleanState extends VacBotCommand_950type {
     constructor() {
-        super('GetCleanState');
+        super('getCleanInfo');
     }
 }
 
 class GetChargeState extends VacBotCommand_950type {
     constructor() {
-        super('GetChargeState');
+        super('getChargeState');
     }
 }
 
 class GetBatteryState extends VacBotCommand_950type {
     constructor() {
-        super('GetBatteryInfo');
+        super('getBattery');
     }
 }
 
 class GetLifeSpan extends VacBotCommand_950type {
     constructor(component) {
-        super('GetLifeSpan', [constants_type.COMPONENT_TO_ECOVACS[component]]);
+        super('getLifeSpan', [constants_type.COMPONENT_TO_ECOVACS[component]]);
     }
 }
 
 class SetTime extends VacBotCommand_950type {
     constructor(timestamp, timezone) {
-        super('SetTime', {
+        super('setTime', {
             'time': {
                 't': timestamp,
                 'tz': timezone
@@ -140,7 +146,7 @@ class SetTime extends VacBotCommand_950type {
 
 class GetCleanSpeed extends VacBotCommand_950type {
     constructor(component) {
-        super('GetCleanSpeed');
+        super('getSpeed');
     }
 }
 
@@ -149,7 +155,7 @@ class SetWaterLevel extends VacBotCommand_950type {
         if (constants_type.WATER_LEVEL_TO_ECOVACS.hasOwnProperty(level)) {
             level = constants_type.WATER_LEVEL_TO_ECOVACS[level];
         }
-        super('SetWaterPermeability', {
+        super('setWaterInfo', {
             'amount': level
         });
     }
@@ -157,19 +163,18 @@ class SetWaterLevel extends VacBotCommand_950type {
 
 class GetWaterInfo extends VacBotCommand_950type {
     constructor() {
-        super('GetWaterInfo');
+        super('getWaterInfo');
     }
 }
-
-class GetDeebotPos extends VacBotCommand_950type {
+class GetPosition extends VacBotCommand_950type {
     constructor() {
-        super('GetDeebotPos');
+        super('getPos', ["chargePos", "deebotPos"]);
     }
 }
 
 class PlaySound extends VacBotCommand_950type {
     constructor(sid = '0') {
-        super('PlaySound', {'count': 1, 'sid': sid});
+        super('playSound', {'count': 1, 'sid': sid});
     }
 }
 
@@ -182,14 +187,15 @@ module.exports.Stop = Stop;
 module.exports.Pause = Pause;
 module.exports.Resume = Resume;
 module.exports.Charge = Charge;
-module.exports.GetDeebotPos = GetDeebotPos;
 module.exports.GetDeviceInfo = GetDeviceInfo;
 module.exports.GetCleanState = GetCleanState;
 module.exports.GetChargeState = GetChargeState;
 module.exports.GetBatteryState = GetBatteryState;
 module.exports.GetLifeSpan = GetLifeSpan;
+module.exports.GetPosition = GetPosition;
 module.exports.SetTime = SetTime;
 module.exports.GetCleanSpeed = GetCleanSpeed;
 module.exports.GetWaterInfo = GetWaterInfo;
 module.exports.SetWaterLevel = SetWaterLevel;
 module.exports.PlaySound = PlaySound;
+module.exports.Relocate = Relocate;


### PR DESCRIPTION
Folgende Funktionen für den 950 implementiert/korrigiert:
| action        |  arguments |   emits events  |
|-------------|--------------|-------------------|
| GetPosition   | none |    DeebotPosition,  ChargePosition |
| GetCleanSpeed | none |  FanSpeed        |
| relocate      | none |   RelocationState | 

Removed COMMAND_TO_ECOVACS from ecovacsConstants_950type.js