### PR TITLE
Fixes / Checks from roadmap for 950

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ node_modules
 test-results.xml
 .cache/
 /.nyc_output/
+launch.json
+app_BWE.js
+logs

--- a/library/ecovacsMQTT_JSON.js
+++ b/library/ecovacsMQTT_JSON.js
@@ -333,9 +333,9 @@ class EcovacsMQTT_JSON extends EventEmitter {
                 break;
             case "pos":
                 this.bot._handle_position(event);
-                if(this.bot.deebot_position["invalid"]==1) {
-                    this.bot._handle_error({"resultCode":"0","resultCodeMessage":"ok","resultData":{"code":[102]}});
-                    this.emit("Error", this.bot.error_event);
+                if(this.bot.deebot_position["invalid"]==1 && this.bot.relocation_state == 'ok') {
+                    this.bot.relocation_state = 'required';
+                    this.emit("RelocationState", this.bot.relocation_state);
                 } else {
                     this.emit("DeebotPosition", this.bot.deebot_position["x"]+","+this.bot.deebot_position["y"]+","+this.bot.deebot_position["a"]);
                 }

--- a/library/ecovacsMQTT_JSON.js
+++ b/library/ecovacsMQTT_JSON.js
@@ -368,6 +368,12 @@ class EcovacsMQTT_JSON extends EventEmitter {
                 this.bot._handle_error(event);
                 this.emit("Error", this.bot.error_event);
                 break;
+            case 'totalstats':
+                this.bot._handle_cleanSum(event);
+                this.emit("CleanSum_squareMeters", this.bot.cleanSum_squareMeters);
+                this.emit("CleanSum_totalSeconds", this.bot.cleanSum_totalSeconds);
+                this.emit("CleanSum_totalNumber", this.bot.cleanSum_totalNumber);
+                break;
             default:
                 tools.envLog("[EcovacsMQTT_JSON] Unknown command received: %s", command);
                 break;

--- a/library/errorCodes.js
+++ b/library/errorCodes.js
@@ -1,4 +1,5 @@
 const CODES = {
+    '0': 'NoError: Robot is operational',
     '100': 'NoError: Robot is operational',
     '101': 'BatteryLow: Low battery',
     '102': 'HostHang: Robot is off the floor',
@@ -23,6 +24,12 @@ const CODES = {
     '201': 'AirFilterUninstall:',
     '202': 'UltrasonicComponentAbnormal',
     '203': 'SmallWheelError',
+    '204': 'WheelHang',
+    '205': 'IonSterilizeExhausted',
+    '206': 'IonSterilizeAbnormal',
+    '207': 'IonSterilizeFault',
+    '601': 'ERROR_ClosedAIVISideAbnormal',
+    '602': 'ClosedAIVIRollAbnormal',
     'UNKNOW': 'unknown'
 };
 

--- a/library/vacBotCommand_950type.js
+++ b/library/vacBotCommand_950type.js
@@ -204,7 +204,11 @@ class GetNetInfo extends VacBotCommand_950type {
         super('getNetInfo');
     }
 }
-
+class GetCleanSum extends VacBotCommand_950type {
+    constructor() {
+        super('getTotalStats');
+    }
+}
 class GetCurrentMapName extends VacBotCommand_950type {
     constructor(sid = '0') {
         super('getCachedMapInfo');
@@ -244,3 +248,4 @@ module.exports.GetCurrentMapName = GetCurrentMapName;
 module.exports.GetError = GetError;
 module.exports.GetNetInfo = GetNetInfo;
 module.exports.GetSleepStatus = GetSleepStatus;
+module.exports.GetCleanSum = GetCleanSum;

--- a/library/vacBotCommand_950type.js
+++ b/library/vacBotCommand_950type.js
@@ -75,9 +75,10 @@ class Stop extends VacBotCommand_950type {
 }
 
 class SpotArea extends Clean {
-    constructor(action = 'start', area = '') {
+    constructor(action = 'start', area = '', cleanings = 1) {
         if (area !== '') {
-            super('spotArea', action, {'content': area, 'count': '1'});
+            let cleaningAsNumber = parseInt(cleanings);
+            super('spotArea', action, {'content': area, 'count': cleaningAsNumber});
         }
     }
 }

--- a/library/vacBotCommand_950type.js
+++ b/library/vacBotCommand_950type.js
@@ -193,7 +193,7 @@ class GetPosition extends VacBotCommand_950type {
 }
 
 class PlaySound extends VacBotCommand_950type {
-    constructor(sid = '0') {
+    constructor(sid = 0) {
         super('playSound', {'count': 1, 'sid': sid});
     }
 }

--- a/library/vacBotCommand_950type.js
+++ b/library/vacBotCommand_950type.js
@@ -194,7 +194,8 @@ class GetPosition extends VacBotCommand_950type {
 
 class PlaySound extends VacBotCommand_950type {
     constructor(sid = 0) {
-        super('playSound', {'count': 1, 'sid': sid});
+        let sidAsNumber = parseInt(sid);
+        super('playSound', {'count': 1, 'sid': sidAsNumber});
     }
 }
 

--- a/library/vacBotCommand_950type.js
+++ b/library/vacBotCommand_950type.js
@@ -85,7 +85,8 @@ class SpotArea extends Clean {
 class CustomArea extends Clean {
     constructor(action = 'start', map_position = '', cleanings = 1) {
         if (map_position !== '') {
-            super('customArea', action, {'content': map_position, 'count': cleanings});
+            let cleaningAsNumber = parseInt(cleanings);
+            super('customArea', action, {'content': map_position, 'count': cleaningAsNumber});
         }
     }
 }

--- a/library/vacBot_950type.js
+++ b/library/vacBot_950type.js
@@ -361,8 +361,11 @@ class VacBot_950type {
       case "spotarea":
         if (arguments.length < 3) {
           return;
+        } else if (arguments.length == 3) {
+          this.send_command(new vacBotCommand.SpotArea(arguments[1], arguments[2]));
+        } else { // including number of cleanings
+          this.send_command(new vacBotCommand.SpotArea(arguments[1], arguments[2], arguments[3]));
         }
-        this.send_command(new vacBotCommand.SpotArea(arguments[1], arguments[2]));
         break;
       case "customarea":
         if (arguments.length < 4) {

--- a/library/vacBot_950type.js
+++ b/library/vacBot_950type.js
@@ -227,6 +227,10 @@ class VacBot_950type {
         if(dictionary.CLEAN_MODE_FROM_ECOVACS[event['resultData']['state']] == 'returning') { //set charge state on returning to dock
           this.charge_status = dictionary.CLEAN_MODE_FROM_ECOVACS[event['resultData']['state']];
           tools.envLog("[VacBot] *** charge_status = %s", this.charge_status);
+        } else if(dictionary.CLEAN_MODE_FROM_ECOVACS[event['resultData']['state']] == 'idle') {
+          //when clean state = idle the bot can be charging on the dock or the return to dock has been canceled
+          //if this is not run, the status when canceling the return stays on 'returning'
+          this.run('GetChargeState');
         }
       }
     } else {

--- a/library/vacBot_950type.js
+++ b/library/vacBot_950type.js
@@ -34,12 +34,16 @@ class VacBot_950type {
     this.currentMapName = 'unknown';
     this.currentMapMID = null;
     this.currentMapIndex = null;
-
+    
     this.netInfoIP = null;
     this.netInfoWifiSSID = null;
     this.netInfoWifiSignal = null;
     this.netInfoMAC = null;
     
+    this.cleanSum_squareMeters = null;
+    this.cleanSum_totalSeconds = null;
+    this.cleanSum_totalNumber = null;
+
     tools.envLog("[VacBot] Using EcovacsIOTMQ_JSON");
     const EcovacsMQTT = require('./ecovacsMQTT_JSON.js');
     this.ecovacs = new EcovacsMQTT(this, user, hostname, resource, secret, continent, vacuum, server_address);
@@ -61,6 +65,8 @@ class VacBot_950type {
       this.run('GetCurrentMapName');
       this.run('GetError');
       this.run('GetSleepStatus');
+      
+      this.run('GetCleanSum');
       
        //this.run('relocate');
       if (this.hasMoppingSystem()) {
@@ -239,6 +245,12 @@ class VacBot_950type {
     tools.envLog("[VacBot] *** clean_status = %s", this.clean_status);
   }
 
+  _handle_cleanSum(event) {
+    this.cleanSum_squareMeters = parseInt(event['resultData']['area']);
+    this.cleanSum_totalSeconds = parseInt(event['resultData']['time']);
+    this.cleanSum_totalNumber = parseInt(event['resultData']['count']);
+  }
+
   _handle_battery_info(event) {
     this.battery_status = event['resultData']['value'];
     tools.envLog("[VacBot] *** battery_status = %d\%", this.battery_status);
@@ -407,6 +419,9 @@ class VacBot_950type {
         break;
       case "getcleanspeed":
         this.send_command(new vacBotCommand.GetCleanSpeed());
+        break;
+      case "getcleansum":
+        this.send_command(new vacBotCommand.GetCleanSum());
         break;
       case "getchargestate":
         this.send_command(new vacBotCommand.GetChargeState());


### PR DESCRIPTION
	- Custom area cleanings as 5th Parameter in customArea (OZMO 950: customArea_cleanings (v0.5.4) #33)
		--> done (explicit cast to number)
	- enhance relocationState (if position is invalid should be set to "required" but not overwrite result of last relocation (e.g. if failed)
		--> done, documentation: https://github.com/mrbungle64/ecovacs-deebot.js/wiki/Relocate
	- implement number of cleanings for 950 spot areas
		--> done
	- check command "charge" with { "act": "stop" } (chargestatus stays on "returning" when using stop button
		--> logic fixed without implementing charge-stop command
	- playSound should make the connection "beep" on 950, not "I am here"
		--> is now also a melody (not the connection beep). 0 is the melody with 950, too but the default was to set as '0' (string) instead of 0 (as number) so the API defaulted to "I am here"

From other model changes:
	- Implement GetCleanSum (MQTT_JSON)