### PR TITLE
fixing error while deebot gets online

### DIFF
--- a/library/ecovacsMQTT.js
+++ b/library/ecovacsMQTT.js
@@ -243,12 +243,25 @@ class EcovacsMQTT extends EventEmitter {
         const firstChild = xml.childNodes[0];
         let attrs = {};
         let event = null;
+        console.log('TEST' +  xml);
         if (arguments.length > 1) {
             event = firstChild.tagName;
             const action = arguments[1];
             attrs = action.args
         } else {
-            event = firstChild.attributes.getNamedItem('td').value;
+            if (firstChild.attributes == undefined)
+            {
+                let unknownResult = {
+                    'event': 'unknown',
+                    'attrs': '',
+                    'children': []
+                };
+                return unknownResult;
+            }
+            else
+            {
+                event = firstChild.attributes.getNamedItem('td').value;
+            }
         }
         let result = {
             'event': event,

--- a/library/ecovacsMQTT.js
+++ b/library/ecovacsMQTT.js
@@ -243,7 +243,7 @@ class EcovacsMQTT extends EventEmitter {
         const firstChild = xml.childNodes[0];
         let attrs = {};
         let event = null;
-        console.log('TEST' +  xml);
+        tools.envLog('[EcovacsMQTT] xml received: %s',xml);
         if (arguments.length > 1) {
             event = firstChild.tagName;
             const action = arguments[1];


### PR DESCRIPTION
When deebot comes online and a client is attached to MQTT, we receive an event that is not XML and  makes a crash : 

```bash
[2020-4-19 16:30:01] TypeError: Cannot read property 'getNamedItem' of null
    at EcovacsMQTT._command_to_dict (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/ecovacs-deebot/library/ecovacsMQTT.js:253:43)
    at EcovacsMQTT._handle_message_payload (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/ecovacs-deebot/library/ecovacsMQTT.js:236:27)
    at MqttClient.<anonymous> (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/ecovacs-deebot/library/ecovacsMQTT.js:82:18)
    at MqttClient.emit (events.js:311:20)
    at MqttClient._handlePublish (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:1162:12)
    at MqttClient._handlePacket (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:351:12)
    at work (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:283:12)
    at Writable.writable._write (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:294:5)
    at doWrite (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/readable-stream/lib/_stream_writable.js:428:64)
    at writeOrBuffer (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/readable-stream/lib/_stream_writable.js:417:5)
    at Writable.write (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/readable-stream/lib/_stream_writable.js:334:11)
    at TLSSocket.ondata (_stream_readable.js:714:22)
    at TLSSocket.emit (events.js:311:20)
    at addChunk (_stream_readable.js:294:12)
    at readableAddChunk (_stream_readable.js:275:11)
    at TLSSocket.Readable.push (_stream_readable.js:209:10)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:186:23)
```

The content of the event is the following : 
```json
{"td":"GetIOTConnStatus","on":1,"conn":2,"ip":"47.254.143.26"}
```

Steps to reproduce : 
- Attach a client 
- Stop deebot (power off)
- Power it on : event is received and generates the crash.