### PR TITLE
convert errorCode to String (950)

### DIFF
--- a/library/vacBot_950type.js
+++ b/library/vacBot_950type.js
@@ -471,7 +471,7 @@ class VacBot_950type {
 
   _handle_error(event) {
     
-    this.errorCode = event['resultData']['code'];
+    this.errorCode = event['resultData']['code'].toString();
 
     if (errorCodes[this.errorCode]) { // known errorCode from library
       this.errorDescription = errorCodes[this.errorCode];


### PR DESCRIPTION
errorCode was emitted from the library as object and thus the comparison by setStateConditional was always failing, resulting in state changes every minute (refresh interval)
setStateConditional previous value: 0 of type object (debug)
setStateConditional value to be set: 0 of type object (debug)
state change info.errorCode => 0
Explicit conversion to string fixed that behaviour