### PR TITLE
https://github.com/nicoduj/homebridge-deebotEcovacs/issues/19

### DIFF
--- a/library/ecovacsMQTT.js
+++ b/library/ecovacsMQTT.js
@@ -25,9 +25,9 @@ class EcovacsMQTT extends EventEmitter {
         this.bot = bot;
         this.user = user;
         this.hostname = hostname;
-        this.domain = this.hostname.split(".")[0]; // MQTT is using domain without tld extension
+        this.customdomain = this.hostname.split(".")[0]; // MQTT is using domain without tld extension
         this.resource = resource;
-        this.username = this.user + '@' + this.domain;
+        this.username = this.user + '@' + this.customdomain;
         this.clientId = this.username + '/' + this.resource;
         this.secret = secret;
         this.continent = continent;


### PR DESCRIPTION
Not sure it will solve some issues like this one, but I think since it extends eventEmiter and EventEmitter has this property "domain", it could lead to some errors like this :  
https://github.com/nicoduj/homebridge-deebotEcovacs/issues/19

