### PR TITLE
vacBot950Type now clears interval on disconnect. otherwise node runs forever

### DIFF
--- a/library/vacBot_950type.js
+++ b/library/vacBot_950type.js
@@ -672,6 +672,7 @@ class VacBot_950type {
   disconnect() {
     this.ecovacs.disconnect();
     this.is_ready = false;
+    clearInterval(this.ping_interval)
   }
 }
 


### PR DESCRIPTION
The disconnect method is not clearing the ping interval on disconnect. Interval must be cleared in order for node to stop. Otherwise it runs forever...