### PR TITLE
TypeError: Cannot read property 'getNamedItem' of null

### DIFF
--- a/library/ecovacsMQTT_XML.js
+++ b/library/ecovacsMQTT_XML.js
@@ -183,7 +183,7 @@ class EcovacsMQTT_XML extends EcovacsMQTT {
             const action = arguments[1];
             attrs = action.args
         } else {
-            if (!firstChild || (firstChild.attributes === undefined)) {
+            if (!firstChild || (firstChild.attributes === null)) {
                 return {
                     'event': 'unknown',
                     'attrs': '',


### PR DESCRIPTION
Hi,

While testing the problem in my lib for disconnection, I had this error : 

``` log
[2021-2-27 10:13:45] TypeError: Cannot read property 'getNamedItem' of null
    at EcovacsMQTT_XML._command_to_dict (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/ecovacs-deebot/library/ecovacsMQTT_XML.js:195:47)
    at EcovacsMQTT_XML._handle_message (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/ecovacs-deebot/library/ecovacsMQTT_XML.js:168:27)
    at MqttClient.<anonymous> (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/ecovacs-deebot/library/ecovacsMQTT.js:42:18)
    at MqttClient.emit (events.js:311:20)
    at MqttClient._handlePublish (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:1277:12)
    at MqttClient._handlePacket (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:410:12)
    at work (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:321:12)
    at Writable.writable._write (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/lib/client.js:335:5)
    at doWrite (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/node_modules/readable-stream/lib/_stream_writable.js:409:139)
    at writeOrBuffer (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/node_modules/readable-stream/lib/_stream_writable.js:398:5)
    at Writable.write (/Users/nicolas/Documents/GitHub/HomebridgePlugins/homebridge-deebotEcovacs-master/node_modules/mqtt/node_modules/readable-stream/lib/_stream_writable.js:307:11)
    at TLSSocket.ondata (_stream_readable.js:714:22)
    at TLSSocket.emit (events.js:311:20)
    at addChunk (_stream_readable.js:294:12)
    at readableAddChunk (_stream_readable.js:275:11)
    at TLSSocket.Readable.push (_stream_readable.js:209:10)
    at TLSWrap.onStreamRead (internal/stream_base_commons.js:186:23)

```

**Steps to reproduce**

1/ Connect to the deebot
2/ turn it off
3/ wait for some timeout events from run commands
4/turn it on again

Then, an event is recevied which crash the lib (and Homebridge).

XML received :  

```
[EcovacsMQTT] xml received: {"td":"GetIOTConnStatus","on":1,"conn":2,"ip":"47.254.143.26"}
[EcovacsMQTT] xml firstChild Text {
  ownerDocument: Document {
    implementation: { _features: {} },
    childNodes: { '0': [Circular], length: 1 },
    doctype: null,
    documentURI: undefined,
    firstChild: [Circular],
    lastChild: [Circular],
    _inc: 2
  },
  data: '{"td":"GetIOTConnStatus","on":1,"conn":2,"ip":"47.254.143.26"}',
  nodeValue: '{"td":"GetIOTConnStatus","on":1,"conn":2,"ip":"47.254.143.26"}',
  length: 62,
  previousSibling: null,
  nextSibling: null,
  parentNode: Document {
    implementation: { _features: {} },
    childNodes: { '0': [Circular], length: 1 },
    doctype: null,
    documentURI: undefined,
    firstChild: [Circular],
    lastChild: [Circular],
    _inc: 2
  }
}
```