### PR TITLE
Combined cleaninfo+waterinfo

### DIFF
--- a/library/ecovacs.js
+++ b/library/ecovacs.js
@@ -80,6 +80,16 @@ class Ecovacs extends EventEmitter {
                 if (this.bot.lastUsedAreaValues) {
                     this.emit('LastUsedAreaValues', this.bot.lastUsedAreaValues);
                 }
+
+                // report+waterinfo
+                if (this.bot.cleanReport != undefined && this.bot.waterboxInfo != undefined)
+                    this.emit("CleanReportDetails", {
+                        'status': this.bot.cleanReport,
+                        'waterInfo': {
+                            'enabled': this.bot.waterboxInfo,
+                            'level': this.bot.waterLevel
+                        }
+                    });
                 break;
             case 'CleanSpeed':
                 if (event.children && (event.children.length > 0)) {
@@ -136,6 +146,16 @@ class Ecovacs extends EventEmitter {
                     'enabled': this.bot.waterboxInfo,
                     'level': this.bot.waterLevel
                 });
+
+                // report+waterinfo
+                if (this.bot.cleanReport != undefined && this.bot.waterboxInfo != undefined)
+                    this.emit("CleanReportDetails", {
+                        'status': this.bot.cleanReport,
+                        'waterInfo': {
+                            'enabled': this.bot.waterboxInfo,
+                            'level': this.bot.waterLevel
+                        }
+                    });
                 break;
             case 'WaterBoxInfo':
                 this.bot.handle_waterboxInfo(event);
@@ -144,6 +164,16 @@ class Ecovacs extends EventEmitter {
                     'enabled': this.bot.waterboxInfo,
                     'level': this.bot.waterLevel
                 });
+
+                // report+waterinfo
+                if (this.bot.cleanReport != undefined && this.bot.waterboxInfo != undefined)
+                    this.emit("CleanReportDetails", {
+                        'status': this.bot.cleanReport,
+                        'waterInfo': {
+                            'enabled': this.bot.waterboxInfo,
+                            'level': this.bot.waterLevel
+                        }
+                    });
                 break;
             case 'NetInfo':
                 this.bot.handle_netInfo(event.attrs);

--- a/library/ecovacsMQTT_JSON.js
+++ b/library/ecovacsMQTT_JSON.js
@@ -212,6 +212,17 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
             case "cleaninfo":
                 this.bot.handle_cleanReport(event);
                 this.emit("CleanReport", this.bot.cleanReport);
+
+                // report+waterinfo
+                if (this.bot.cleanReport != undefined && this.bot.waterboxInfo != undefined)
+                    this.emit("CleanReportDetails", {
+                        'status': this.bot.cleanReport,
+                        'waterInfo': {
+                            'enabled': this.bot.waterboxInfo,
+                            'level': this.bot.waterLevel
+                        }
+                    });
+
                 if (this.bot.chargeStatus) {
                     this.emit("ChargeState", this.bot.chargeStatus);
                 }
@@ -308,6 +319,16 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
                     'enabled': this.bot.waterboxInfo,
                     'level': this.bot.waterLevel
                 });
+
+                // report+waterinfo
+                if (this.bot.cleanReport != undefined && this.bot.waterboxInfo != undefined)
+                    this.emit("CleanReportDetails", {
+                        'status': this.bot.cleanReport,
+                        'waterInfo': {
+                            'enabled': this.bot.waterboxInfo,
+                            'level': this.bot.waterLevel
+                        }
+                    });
                 break;
             case "netinfo":
                 this.bot.handle_netInfo(event);


### PR DESCRIPTION
Hey @mrbungle64 I've added a new event to combine cleaning status with waterinfo. This makes easier in my MQTT bridge to get the real status (ie: mopping or cleaning) in a central and unique place.