### PR TITLE
Add once method to VacBot class

### DIFF
--- a/library/vacBot.js
+++ b/library/vacBot.js
@@ -664,6 +664,10 @@ class VacBot {
         this.ecovacs.on(name, func);
     }
 
+    once(name, func) {
+        this.ecovacs.once(name, func);
+    }
+
     /**
      * If the value of `company` is `eco-ng`
      * the model uses MQTT as protocol


### PR DESCRIPTION
Adding this method enables one-off event listeners to be registered and automatically handles cleanup once the event has been fired. Since `Ecovacs` extends `EventEmitter`, we can just call `once` on this.ecovacs`.

This enables much easier handling of request-response style patterns from the consuming code, such as this:
```typescript
class ExampleClass {
  // ...

  getBatteryInfo(): Promise<BatteryInfoResponse> {
    return new Promise(resolve => this.deviceConnection.once('BatteryInfo', (event) => resolve(event));
  }
}
```

I've made this change locally and it's working without any issues, so I thought I'd push it upstream.