### PR TITLE
add auto V2 API handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -469,9 +469,16 @@ class EcovacsAPI {
     let vacBotClass;
     const defaultValue = EcovacsAPI.isMQTTProtocolUsed(vacuum['company']);
     const is950Type = EcovacsAPI.isDeviceClass950type(vacuum['class'], defaultValue);
+    const is950Type_v2 = EcovacsAPI.isDeviceClass950v2type(vacuum['class'], defaultValue);
     if (is950Type) {
-      tools.envLogSuccess(`'950type' model identified`);
-      vacBotClass = require('./library/950type/vacBot');
+      if (is950Type_v2){
+        tools.envLogSuccess(`'950type_v2' model identified`);
+        vacBotClass = require('./library/950type_v2/vacBot');
+      }
+      else{
+        tools.envLogSuccess(`'950type' model identified`);
+        vacBotClass = require('./library/950type/vacBot');
+      }
     } else {
       tools.envLogWarn(`'non950type' model identified (deprecated)`);
       vacBotClass = require('./library/non950type/vacBot');

--- a/index.js
+++ b/index.js
@@ -537,6 +537,15 @@ class EcovacsAPI {
   }
 
   /**
+   * Returns true if the device class is 950_v2 type
+   * @param {string} deviceClass - The device class to check
+   * @returns {boolean} the value of the '950type_v2' property
+   */
+  static isDeviceClass950v2type(deviceClass) {
+    return tools.getDeviceProperty(deviceClass, '950type_V2', false);
+  }
+  
+  /**
    * Returns true if the device class is not 950 type
    * @param {string} deviceClass - The device class of the device
    * @returns {boolean} a boolean value.

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -1510,7 +1510,7 @@ class VacBot_950type extends VacBot {
      * @param args - zero or more arguments to perform the command
      */
     run(command, ...args) {
-        super.run(command, ...args);
+        if ( super.run(command, ...args) == true) return true;
         switch (command.toLowerCase()) {
             case 'GetMapInfo'.toLowerCase():
             case 'GetMapImage'.toLowerCase(): {
@@ -2298,7 +2298,10 @@ class VacBot_950type extends VacBot {
             case 'GetEfficiency'.toLowerCase():
                 this.sendCommand(new VacBotCommand.Generic('getEfficiency'));
                 break;
+            default:
+                return false;
         }
+        return true;
     }
 }
 

--- a/library/950type_v2/vacBot.js
+++ b/library/950type_v2/vacBot.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const VacBot = require('../950type/vacBot');
+const tools = require('../tools');
+
+/**
+ * This class is relevant for 950_v2 type models
+ * e.g. Deebot OZMO T80 series (which are all MQTT based models)
+ */
+class VacBot_950v2type extends VacBot {
+
+    run(command, ...args) {
+        // Map 950 commands to V2 variant
+        let command_v2 = command + '_V2';
+
+        // try v2 command first (if available)
+        if (super.run(command_v2, ...args) == false)
+        {
+            // v2 command not found, try original command
+            super.run(command, ...args);
+        }
+
+    }
+}
+
+module.exports = VacBot_950v2type;

--- a/library/vacBot.js
+++ b/library/vacBot.js
@@ -685,7 +685,10 @@ class VacBot {
             case "MoveTurnAround".toLowerCase():
                 this.sendCommand(new this.vacBotCommand.MoveTurnAround());
                 break;
+            default:
+                return false;
         }
+        return true;
     }
 
     /**


### PR DESCRIPTION
Add V2 API handling:
- Add redefinition for vacBot.js for _v2 devices
- Try to execute v2 commands first
- If command is not found, try default command
- Also addes return value for run() function to get a response if the command was found (inside the case statement) or not.

Target: 
- No change for apps required to support V2 devices.
- Apps can call "Clean" command independent if it is a V2 or an older device.
- The module tries to execute _v2 command first and if this is not found, the original command is executed.
- This way, the module itself handles the different versions and it's not needed to adjust apps using this module to call Clean_V2 or Clean.

Please check if this PR matches your idea of the module.
Feel free to ask or adjust the code :-)