### PR TITLE
Add DEEBOT T80S OMNI support (model, zstd map data, V2 spot areas, vector SVG map, V2/Stats status)

### DIFF
--- a/index.js
+++ b/index.js
@@ -560,6 +560,95 @@ class EcovacsAPI {
    * @param {number} [deviceNumber=0] - the device number is a number that is assigned to each device
    * @returns {string} the device ID
    */
+  // ---------------------------------------------------------------------------
+  // Device verification — recovery for Ecovacs error 1013
+  // ("Please update to the latest version to continue.")
+  //
+  // Since mid-July 2026 Ecovacs rejects logins with code 1013. This is a
+  // per-deviceId device-trust block, NOT an appVersion problem: a deviceId that
+  // has completed a one-time email verification logs in normally again (even on
+  // the old appVersion). These methods perform that verification for THIS
+  // deviceId. They sign with the app keys published in deebot-client and
+  // appVersion 3.14.0, independently of the normal login signing.
+  // ---------------------------------------------------------------------------
+
+  _deviceVerifyMeta() {
+    const cc = ({ 'GB': 'UK' }[this.country] || this.country).toLowerCase();
+    return {
+      base: `https://gl-${cc}-api.${this.authDomain || constants.AUTH_DOMAIN}`,
+      sign: { country: cc, lang: 'EN', deviceId: this.deviceId, appCode: 'global_e',
+              appVersion: '3.14.0', channel: 'google_play', deviceType: '1' },
+      path: `/v1/private/${cc}/EN/${this.deviceId}/global_e/3.14.0/google_play/1`
+    };
+  }
+
+  async _deviceVerifyRequest(endpoint, params) {
+    const KEY = '1520391301804';
+    const SECRET = '6c319b2a5cd3e66e39159c2e28f2fce9';
+    const meta = this._deviceVerifyMeta();
+    const base = {
+      requestId: EcovacsAPI.md5(String(Date.now() / 1000)),
+      authTimespan: Date.now(),
+      authTimeZone: 'GMT-8'
+    };
+    const all = { ...meta.sign, ...base, ...params };
+    let text = KEY;
+    Object.keys(all).sort().forEach((k) => { text += `${k}=${all[k]}`; });
+    text += SECRET;
+    const query = { ...base, ...params, authSign: EcovacsAPI.md5(text), authAppkey: KEY };
+    const res = await axios.get(`${meta.base}${meta.path}${endpoint}`, { params: query });
+    const body = (res && res.data) || {};
+    if (String(body.code) !== '0000') {
+      throw new Error(`Ecovacs verify ${endpoint} -> code=${body.code} msg=${body.msg}`);
+    }
+    return body.data || {};
+  }
+
+  async getDeviceVerifyPublicKey() {
+    const data = await this._deviceVerifyRequest('/common/getConfig', { keys: 'PUBLIC.KEY.CONFIG' });
+    for (const e of data) {
+      if (e && e.key === 'PUBLIC.KEY.CONFIG') return JSON.parse(e.value).publicKey;
+    }
+    throw new Error('PUBLIC.KEY.CONFIG missing from getConfig response');
+  }
+
+  _deviceVerifyEncrypt(publicKeyBase64, value) {
+    const key = crypto.createPublicKey({ key: Buffer.from(publicKeyBase64, 'base64'), format: 'der', type: 'spki' });
+    return crypto.publicEncrypt({ key, padding: crypto.constants.RSA_PKCS1_PADDING }, Buffer.from(value)).toString('base64');
+  }
+
+  /**
+   * Email a one-time device-verification code to the account.
+   * @param {string} accountId - the account email
+   */
+  async sendDeviceVerifyCode(accountId) {
+    const pub = await this.getDeviceVerifyPublicKey();
+    await this._deviceVerifyRequest('/user/sendEmailVerifyCode', {
+      encryptEmail: this._deviceVerifyEncrypt(pub, accountId),
+      verifyType: 'EMAIL_VERIFY_DEVICE',
+      supportChar: 'N',
+      isForce: 'N'
+    });
+    return true;
+  }
+
+  /**
+   * Verify this deviceId with the emailed code. After this, the normal login works again.
+   * @param {string} accountId - the account email
+   * @param {string} code - the emailed verification code
+   */
+  async verifyDevice(accountId, code) {
+    const pub = await this.getDeviceVerifyPublicKey();
+    await this._deviceVerifyRequest('/user/verifyDevice', {
+      encryptAccount: this._deviceVerifyEncrypt(pub, accountId),
+      backUpEmail: '',
+      verifyCode: code,
+      model: 'Pixel 7',
+      system: 'Android 14'
+    });
+    return true;
+  }
+
   static getDeviceId(machineId, deviceNumber = 0) {
     return EcovacsAPI.md5(machineId + deviceNumber.toString());
   }

--- a/library/950type/ecovacsMQTT_JSON.js
+++ b/library/950type/ecovacsMQTT_JSON.js
@@ -590,7 +590,10 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
             }
             case "MapInfo_V2": {
                 try {
-                    this.vacBot.handleMapInfoV2(payload);
+                    await this.vacBot.handleMapInfoV2(payload);
+                    if (this.vacBot.mapImageV2 && this.vacBot.mapImageV2.svg) {
+                        this.emitMessage("MapImageV2", this.vacBot.mapImageV2);
+                    }
                 } catch (e) {
                     tools.envLogError(`error on handling MapInfo_V2: ${e.message}`);
                 }

--- a/library/950type/ecovacsMQTT_JSON.js
+++ b/library/950type/ecovacsMQTT_JSON.js
@@ -421,6 +421,15 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
                     });
                     this.vacBot.chargePosition["changeFlag"] = false;
                 }
+                // Live map overlay: re-render the robot marker on position changes
+                // (opt-in, throttled, no extra cloud request).
+                if (this.vacBot.createMapImageOnPositionChange) {
+                    const liveMap = this.vacBot.buildLiveMapImageV2();
+                    if (liveMap) {
+                        this.vacBot.mapImageV2 = liveMap;
+                        this.emitMessage("MapImageV2", liveMap);
+                    }
+                }
                 break;
             }
             case 'QuickCommand': {

--- a/library/950type/ecovacsMQTT_JSON.js
+++ b/library/950type/ecovacsMQTT_JSON.js
@@ -614,6 +614,17 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
             case "MapSet_V2": {
                 await this.vacBot.handleMapSet_V2(payload);
                 this.emitMessage("MapSet_V2", this.vacBot.mapSet_V2);
+                // For V2 devices the spot areas are only delivered via MapSet_V2.
+                // Emit the same events as the non-V2 path so consumers create
+                // the spot area objects.
+                if ((payload['type'] === 'ar') && this.vacBot.mapSpotAreas) {
+                    this.emitMessage("MapSpotAreas", this.vacBot.mapSpotAreas);
+                    if (Array.isArray(this.vacBot.mapSpotAreaInfos_lastV2)) {
+                        for (const spotAreaInfo of this.vacBot.mapSpotAreaInfos_lastV2) {
+                            this.emitMessage("MapSpotAreaInfo", spotAreaInfo);
+                        }
+                    }
+                }
                 break;
             }
             case "MapSubSet": {

--- a/library/950type/ecovacsMQTT_JSON.js
+++ b/library/950type/ecovacsMQTT_JSON.js
@@ -532,7 +532,11 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
             case "WaterInfo": {
                 // "Water Flow Level"
                 this.vacBot.handleWaterInfo(payload);
-                this.emitMessage("WaterLevel", this.vacBot.waterLevel);
+                // Some models (e.g. DEEBOT T80S OMNI with OZMO roller) do not report a
+                // numeric water level; only emit it when a value is actually present
+                if ((this.vacBot.waterLevel !== undefined) && (this.vacBot.waterLevel !== null)) {
+                    this.emitMessage("WaterLevel", this.vacBot.waterLevel);
+                }
                 this.emitMessage("WaterBoxInfo", this.vacBot.waterboxInfo);
                 if (this.vacBot.moppingType !== null) {
                     this.emitMessage("WaterBoxMoppingType", this.vacBot.moppingType);

--- a/library/950type/ecovacsMQTT_JSON.js
+++ b/library/950type/ecovacsMQTT_JSON.js
@@ -494,6 +494,12 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
                     this.emitMessage("CurrentStats", this.vacBot.currentStats);
                     this.vacBot.currentStats = null;
                 }
+                // Newer models report the working state via Stats (stopReason),
+                // not via CleanInfo -> forward it as a CleanReport.
+                if (this.vacBot.cleanReportFromStats) {
+                    this.emitMessage("CleanReport", this.vacBot.cleanReport);
+                    this.vacBot.cleanReportFromStats = false;
+                }
                 break;
             }
             case 'SweepMode': {

--- a/library/950type/ecovacsMQTT_JSON.js
+++ b/library/950type/ecovacsMQTT_JSON.js
@@ -271,8 +271,10 @@ class EcovacsMQTT_JSON extends EcovacsMQTT {
                 this.emitMessage("CleanCount", this.vacBot.cleanCount);
                 break;
             }
-            case "CleanInfo": {
+            case "CleanInfo":
+            case "CleanInfo_V2": {
                 // Various information about the cleaning status
+                // ("_V2" is the variant newer models like the T80S OMNI push)
                 this.vacBot.handleCleanInfo(payload);
                 this.emitMessage("CleanReport", this.vacBot.cleanReport);
                 this.emitMoppingSystemReport();

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -6,6 +6,7 @@ const tools = require('../tools');
 const mapTools = require('../mapTools');
 const map = require('../mapInfo');
 const mapTemplate = require('../mapTemplate');
+const mapImageV2 = require('../mapImageV2');
 const dictionary = require('./dictionary');
 const {errorCodes} = require('../errorCodes.json');
 const {eventCodes} = require('../eventCodes.json');
@@ -886,18 +887,35 @@ class VacBot_950type extends VacBot {
      * Handle the payload of the 'MapInfo_V2' response/message
      * @param {Object} payload
      */
-    handleMapInfoV2(payload) {
+    async handleMapInfoV2(payload) {
         this.currentMapMID = payload['mid'];
+        this.mapImageV2 = null;
         tools.envLogNotice(`mid: ${this.currentMapMID}`);
-        tools.envLogNotice(`batid: ${payload['batid']}`);
-        tools.envLogNotice(`serial: ${payload['serial']}`);
-        tools.envLogNotice(`index: ${payload['index']}`);
         tools.envLogNotice(`type: ${payload['type']}`);
-        tools.envLogNotice(`outlineVer: ${payload['outlineVer']}`);
-        tools.envLogNotice(`info: ${payload['info']}`);
         tools.envLogNotice(`infoSize: ${payload['infoSize']}`);
-        tools.envLogNotice(`using: ${payload['using']}`);
-        tools.envLogNotice(`outlineCpmplete: ${payload['outlineCpmplete']}`); // The typo in 'Cpmplete' is intended
+        // The `info` field is base64 + Zstandard and holds the vector map
+        // (array of [layerType, "roomId;x,y;..."]). Decode it and build an SVG.
+        try {
+            if (payload['info']) {
+                const decoded = await mapTemplate.mapPieceToIntArray(payload['info']);
+                const mapData = (typeof decoded === 'string') ? JSON.parse(decoded) : decoded;
+                const names = {};
+                const infos = this.mapSpotAreaInfos && this.mapSpotAreaInfos[this.currentMapMID];
+                if (infos) {
+                    for (const k in infos) {
+                        if (Object.prototype.hasOwnProperty.call(infos, k) && infos[k] && infos[k].mapSpotAreaName) {
+                            names[k] = infos[k].mapSpotAreaName;
+                        }
+                    }
+                }
+                const svg = mapImageV2.buildRoomsSvg(mapData, {names});
+                if (svg) {
+                    this.mapImageV2 = {mapID: this.currentMapMID, svg};
+                }
+            }
+        } catch (e) {
+            tools.envLogError('Failed to build map SVG from MapInfo_V2: ' + e.message);
+        }
     }
 
     /**

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -935,10 +935,15 @@ class VacBot_950type extends VacBot {
                 // Cache the decoded rooms so the live overlay can re-render the
                 // robot marker on position changes without re-fetching the map.
                 this.mapImageV2Data = {mapID: this.currentMapMID, mapData, names};
+                const robotPos = this.getLiveRobotPos();
+                let highlight;
+                if (robotPos && this.isCleaningActive()) {
+                    highlight = mapImageV2.roomAtPoint(mapData, robotPos.x, robotPos.y);
+                }
                 const svg = mapImageV2.buildRoomsSvg(mapData, {
                     names,
-                    highlight: this.getCleaningHighlight(),
-                    robotPos: this.getLiveRobotPos(),
+                    highlight,
+                    robotPos,
                     chargePos: this.chargePosition
                 });
                 if (svg) {
@@ -951,20 +956,12 @@ class VacBot_950type extends VacBot {
     }
 
     /**
-     * Returns the spot area id to highlight (the room currently being cleaned),
-     * or undefined. Only highlights while an actual cleaning motion is running.
-     * @returns {(string|number|undefined)}
+     * Whether an actual cleaning motion is currently running.
+     * @returns {boolean}
      */
-    getCleaningHighlight() {
+    isCleaningActive() {
         const cleaningStates = ['auto', 'spot', 'spot_area', 'single_room', 'edge', 'freeClean'];
-        const dp = this.deebotPosition;
-        if (dp && dp.currentSpotAreaID !== undefined && dp.currentSpotAreaID !== null
-            && String(dp.currentSpotAreaID) !== 'unknown'
-            && Number(dp.currentSpotAreaID) >= 0
-            && cleaningStates.includes(this.cleanReport)) {
-            return dp.currentSpotAreaID;
-        }
-        return undefined;
+        return cleaningStates.includes(this.cleanReport);
     }
 
     /**
@@ -987,10 +984,15 @@ class VacBot_950type extends VacBot {
         if (!data || String(data.mapID) !== String(this.currentMapMID)) return null;
         const now = Date.now();
         if (this._liveMapLastTs && (now - this._liveMapLastTs) < 1000) return null;
+        const robotPos = this.getLiveRobotPos();
+        let highlight;
+        if (robotPos && this.isCleaningActive()) {
+            highlight = mapImageV2.roomAtPoint(data.mapData, robotPos.x, robotPos.y);
+        }
         const svg = mapImageV2.buildRoomsSvg(data.mapData, {
             names: data.names,
-            highlight: this.getCleaningHighlight(),
-            robotPos: this.getLiveRobotPos(),
+            highlight,
+            robotPos,
             chargePos: this.chargePosition
         });
         if (!svg) return null;

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -1087,6 +1087,38 @@ class VacBot_950type extends VacBot {
                 'mid': payload['mid'],
                 'subsets': subsetData
             };
+            // Also build the spot area structures and expose them so the
+            // 'MapSpotAreas'/'MapSpotAreaInfo' events can be emitted for V2
+            // devices (e.g. DEEBOT T80S OMNI), whose map set is only sent as
+            // MapSet_V2 and was therefore never turned into spot area objects.
+            if (type === 'ar') {
+                const mapID = payload['mid'];
+                const mapSpotAreas = new map.EcovacsMapSpotAreas(mapID, payload['msid']);
+                const mapSpotAreaInfos = [];
+                subsets.forEach((subset) => {
+                    const mssid = subset[0];
+                    mapSpotAreas.push(new map.EcovacsMapSpotArea(mssid));
+                    const info = new map.EcovacsMapSpotAreaInfo(
+                        mapID,
+                        mssid,
+                        (subset[3] || '').replace(/-/g, ','),
+                        '',
+                        subset[2],
+                        subset[1]
+                    );
+                    if (subset[7]) {
+                        info.setCleanSet(subset[7].replace(/-/g, ','));
+                    }
+                    info.setSequenceNumber(subset[4]);
+                    if (typeof this.mapSpotAreaInfos[mapID] === 'undefined') {
+                        this.mapSpotAreaInfos[mapID] = [];
+                    }
+                    this.mapSpotAreaInfos[mapID][mssid] = info;
+                    mapSpotAreaInfos.push(info);
+                });
+                this.mapSpotAreas = mapSpotAreas;
+                this.mapSpotAreaInfos_lastV2 = mapSpotAreaInfos;
+            }
         }
     }
 
@@ -1564,7 +1596,11 @@ class VacBot_950type extends VacBot {
             case 'GetSpotAreas'.toLowerCase(): {
                 const mapID = args[0]; // mapID is a string
                 if (Number(mapID) > 0) {
-                    this.sendCommand(new VacBotCommand.GetMapSpotAreas(mapID));
+                    if (this.is950type_V2()) {
+                        this.sendCommand(new VacBotCommand.GetMapSpotAreas_V2(mapID));
+                    } else {
+                        this.sendCommand(new VacBotCommand.GetMapSpotAreas(mapID));
+                    }
                 }
                 break;
             }

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -39,6 +39,8 @@ class VacBot_950type extends VacBot {
         this.createMapImageOnPositionChange = false;
         this.mapImageV2Data = null;
         this._liveMapLastTs = 0;
+        this.cleanReportFromStats = false;
+        this._statsCleaning = false;
 
         this.advancedMode = null;
         this.aiBlockPlate = null;
@@ -804,6 +806,21 @@ class VacBot_950type extends VacBot {
             }
             this.obstacleTypes = payload['aitypes'];
         }
+        // Newer models (e.g. DEEBOT T80S OMNI) do not report the working state
+        // via CleanInfo (it stays 'idle'); the Stats message carries it instead:
+        // an empty stopReason means a clean is currently in progress.
+        if (payload.hasOwnProperty('stopReason')) {
+            if (payload['stopReason'] === '') {
+                this.cleanReport = 'freeClean';
+                this.cleanReportFromStats = true;
+                this._statsCleaning = true;
+            } else if (this._statsCleaning) {
+                // a Stats with a stop reason after cleaning -> the clean ended
+                this.cleanReport = 'stop';
+                this.cleanReportFromStats = true;
+                this._statsCleaning = false;
+            }
+        }
     }
 
     /**
@@ -939,7 +956,7 @@ class VacBot_950type extends VacBot {
      * @returns {(string|number|undefined)}
      */
     getCleaningHighlight() {
-        const cleaningStates = ['auto', 'spot', 'spot_area', 'single_room', 'edge'];
+        const cleaningStates = ['auto', 'spot', 'spot_area', 'single_room', 'edge', 'freeClean'];
         const dp = this.deebotPosition;
         if (dp && dp.currentSpotAreaID !== undefined && dp.currentSpotAreaID !== null
             && String(dp.currentSpotAreaID) !== 'unknown'

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -33,6 +33,13 @@ class VacBot_950type extends VacBot {
     constructor(user, hostname, resource, secret, vacuum, continent, country, serverAddress = '', authDomain = '') {
         super(user, hostname, resource, secret, vacuum, continent, country, serverAddress, authDomain);
 
+        // Live map overlay (opt-in). When the adapter sets
+        // createMapImageOnPositionChange = true, the robot marker is
+        // re-rendered on every position push (no extra cloud request).
+        this.createMapImageOnPositionChange = false;
+        this.mapImageV2Data = null;
+        this._liveMapLastTs = 0;
+
         this.advancedMode = null;
         this.aiBlockPlate = null;
         this.aiCleanItemState = {
@@ -908,24 +915,13 @@ class VacBot_950type extends VacBot {
                         }
                     }
                 }
-                // Highlight the room currently being cleaned: the robot's
-                // current spot area, but only while an actual cleaning motion
-                // is running (not while docked / returning / stopped).
-                const cleaningStates = ['auto', 'spot', 'spot_area', 'single_room', 'edge'];
-                let highlight;
-                const dp = this.deebotPosition;
-                if (dp && dp.currentSpotAreaID !== undefined && dp.currentSpotAreaID !== null
-                    && String(dp.currentSpotAreaID) !== 'unknown'
-                    && Number(dp.currentSpotAreaID) >= 0
-                    && cleaningStates.includes(this.cleanReport)) {
-                    highlight = dp.currentSpotAreaID;
-                }
-                // Only draw the robot marker when we have a valid live position.
-                const robotPos = (dp && dp.x !== null && dp.y !== null && !dp.isInvalid) ? dp : undefined;
+                // Cache the decoded rooms so the live overlay can re-render the
+                // robot marker on position changes without re-fetching the map.
+                this.mapImageV2Data = {mapID: this.currentMapMID, mapData, names};
                 const svg = mapImageV2.buildRoomsSvg(mapData, {
                     names,
-                    highlight,
-                    robotPos,
+                    highlight: this.getCleaningHighlight(),
+                    robotPos: this.getLiveRobotPos(),
                     chargePos: this.chargePosition
                 });
                 if (svg) {
@@ -935,6 +931,54 @@ class VacBot_950type extends VacBot {
         } catch (e) {
             tools.envLogError('Failed to build map SVG from MapInfo_V2: ' + e.message);
         }
+    }
+
+    /**
+     * Returns the spot area id to highlight (the room currently being cleaned),
+     * or undefined. Only highlights while an actual cleaning motion is running.
+     * @returns {(string|number|undefined)}
+     */
+    getCleaningHighlight() {
+        const cleaningStates = ['auto', 'spot', 'spot_area', 'single_room', 'edge'];
+        const dp = this.deebotPosition;
+        if (dp && dp.currentSpotAreaID !== undefined && dp.currentSpotAreaID !== null
+            && String(dp.currentSpotAreaID) !== 'unknown'
+            && Number(dp.currentSpotAreaID) >= 0
+            && cleaningStates.includes(this.cleanReport)) {
+            return dp.currentSpotAreaID;
+        }
+        return undefined;
+    }
+
+    /**
+     * Returns the current robot position when valid (to draw a marker), else undefined.
+     * @returns {(Object|undefined)}
+     */
+    getLiveRobotPos() {
+        const dp = this.deebotPosition;
+        return (dp && dp.x !== null && dp.y !== null && !dp.isInvalid) ? dp : undefined;
+    }
+
+    /**
+     * Re-render the vector map SVG from the cached rooms plus the current robot
+     * and dock positions (and cleaning highlight). Keeps a live overlay in sync
+     * on position pushes WITHOUT any additional cloud request. Throttled to 1s.
+     * @returns {(Object|null)} {mapID, svg} or null
+     */
+    buildLiveMapImageV2() {
+        const data = this.mapImageV2Data;
+        if (!data || String(data.mapID) !== String(this.currentMapMID)) return null;
+        const now = Date.now();
+        if (this._liveMapLastTs && (now - this._liveMapLastTs) < 1000) return null;
+        const svg = mapImageV2.buildRoomsSvg(data.mapData, {
+            names: data.names,
+            highlight: this.getCleaningHighlight(),
+            robotPos: this.getLiveRobotPos(),
+            chargePos: this.chargePosition
+        });
+        if (!svg) return null;
+        this._liveMapLastTs = now;
+        return {mapID: data.mapID, svg};
     }
 
     /**

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -1904,7 +1904,9 @@ class VacBot_950type extends VacBot {
             case 'SpotArea_V2'.toLowerCase(): {
                 const area = args[0].toString();
                 if (area !== '') {
-                    if (this.isModelTypeX2()) {
+                    if (this.isModelTypeX2() || this.getDeviceProperty('usesFreeClean')) {
+                        // Some newer models (e.g. T80 OMNI, T50 Pro Gen3) reject spotArea_V2
+                        // and require the freeClean command instead
                         const areaValues = tools.convertAreaValuesForFreeCleanCmd(area);
                         this.run('FreeClean', areaValues);
                     } else {

--- a/library/950type/vacBot.js
+++ b/library/950type/vacBot.js
@@ -908,7 +908,26 @@ class VacBot_950type extends VacBot {
                         }
                     }
                 }
-                const svg = mapImageV2.buildRoomsSvg(mapData, {names});
+                // Highlight the room currently being cleaned: the robot's
+                // current spot area, but only while an actual cleaning motion
+                // is running (not while docked / returning / stopped).
+                const cleaningStates = ['auto', 'spot', 'spot_area', 'single_room', 'edge'];
+                let highlight;
+                const dp = this.deebotPosition;
+                if (dp && dp.currentSpotAreaID !== undefined && dp.currentSpotAreaID !== null
+                    && String(dp.currentSpotAreaID) !== 'unknown'
+                    && Number(dp.currentSpotAreaID) >= 0
+                    && cleaningStates.includes(this.cleanReport)) {
+                    highlight = dp.currentSpotAreaID;
+                }
+                // Only draw the robot marker when we have a valid live position.
+                const robotPos = (dp && dp.x !== null && dp.y !== null && !dp.isInvalid) ? dp : undefined;
+                const svg = mapImageV2.buildRoomsSvg(mapData, {
+                    names,
+                    highlight,
+                    robotPos,
+                    chargePos: this.chargePosition
+                });
                 if (svg) {
                     this.mapImageV2 = {mapID: this.currentMapMID, svg};
                 }

--- a/library/mapImageV2.js
+++ b/library/mapImageV2.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * Renderer for the vector map delivered by newer models via `getMapInfo_V2`.
+ * The (zstd-decompressed) `info` payload is an array of sub-arrays, one per
+ * map layer: [ LAYER_TYPE, "roomId;x,y[,flag];...", ... ] where LAYER_TYPE is
+ * "1" (walls), "2" (outline) or "6" (reachable area). Coordinates are in mm
+ * (robot coordinate system, y points up).
+ */
+
+const PALETTE = [
+    '#4CAF50', '#29b6f6', '#ffb300', '#ef5350', '#7e57c2', '#26a69a',
+    '#ec407a', '#8d6e63', '#42a5f5', '#9ccc65', '#ff7043', '#5c6bc0',
+    '#ffca28', '#66bb6a', '#ab47bc', '#26c6da'
+];
+
+function parsePolygon(polyString) {
+    const parts = polyString.split(';');
+    const room = parts[0];
+    const points = [];
+    for (let i = 1; i < parts.length; i++) {
+        const seg = parts[i];
+        if (!seg) continue;
+        const nums = seg.split(',');
+        const x = Number(nums[0]);
+        const y = Number(nums[1]);
+        if (!isNaN(x) && !isNaN(y)) points.push([x, y]);
+    }
+    return {room, points};
+}
+
+/**
+ * Build an SVG floor plan from the decoded getMapInfo_V2 `info` array.
+ * @param {Array} mapData
+ * @param {Object} [options] - {names, width, background, highlight}
+ * @returns {string|null}
+ */
+function buildRoomsSvg(mapData, options = {}) {
+    if (!Array.isArray(mapData)) return null;
+    const names = options.names || {};
+    const targetWidth = options.width || 1000;
+    const background = options.background || '#0b0b0b';
+    const highlight = options.highlight;
+
+    let layer = mapData.find((s) => Array.isArray(s) && String(s[0]) === '2');
+    if (!layer) layer = mapData.find((s) => Array.isArray(s) && s.length > 1);
+    if (!layer) return null;
+
+    const polys = [];
+    for (let i = 1; i < layer.length; i++) {
+        const p = parsePolygon(layer[i]);
+        if (p.points.length >= 3) polys.push(p);
+    }
+    if (!polys.length) return null;
+
+    let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+    for (const p of polys) for (const [x, y] of p.points) {
+        if (x < minX) minX = x; if (x > maxX) maxX = x;
+        if (y < minY) minY = y; if (y > maxY) maxY = y;
+    }
+    const pad = 400;
+    minX -= pad; maxX += pad; minY -= pad; maxY += pad;
+    const w = maxX - minX, h = maxY - minY;
+    if (w <= 0 || h <= 0) return null;
+    const scale = targetWidth / w;
+    const vw = Math.round(w * scale), vh = Math.round(h * scale);
+    const tx = (x) => Math.round((x - minX) * scale * 10) / 10;
+    const ty = (y) => Math.round((maxY - y) * scale * 10) / 10;
+
+    const parts = [];
+    parts.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + vw + ' ' + vh + '" width="' + vw + '" height="' + vh + '" style="background:' + background + ';border-radius:8px">');
+    polys.forEach((p, idx) => {
+        const d = 'M ' + p.points.map(([x, y]) => tx(x) + ',' + ty(y)).join(' L ') + ' Z';
+        const col = PALETTE[idx % PALETTE.length];
+        const isHi = highlight !== undefined && String(highlight) === String(p.room);
+        const fillOpacity = isHi ? 0.85 : 0.5;
+        const strokeW = isHi ? 4 : 2.5;
+        parts.push('<path d="' + d + '" fill="' + col + '" fill-opacity="' + fillOpacity + '" stroke="' + col + '" stroke-width="' + strokeW + '"/>');
+        let cx = 0, cy = 0;
+        for (const [x, y] of p.points) { cx += tx(x); cy += ty(y); }
+        cx = Math.round(cx / p.points.length);
+        cy = Math.round(cy / p.points.length);
+        const label = names[p.room] || p.room;
+        parts.push('<text x="' + cx + '" y="' + cy + '" fill="#fff" font-size="17" font-weight="bold" font-family="sans-serif" text-anchor="middle" style="paint-order:stroke;stroke:#000;stroke-width:3px">' + label + '</text>');
+    });
+    parts.push('</svg>');
+    return parts.join('\n');
+}
+
+module.exports.buildRoomsSvg = buildRoomsSvg;

--- a/library/mapImageV2.js
+++ b/library/mapImageV2.js
@@ -163,4 +163,49 @@ function buildRoomsSvg(mapData, options = {}) {
     return parts.join('\n');
 }
 
+/**
+ * Ray-casting point-in-polygon test.
+ * @param {number} x
+ * @param {number} y
+ * @param {Array<Array<number>>} points
+ * @returns {boolean}
+ */
+function pointInPolygon(x, y, points) {
+    let inside = false;
+    for (let i = 0, j = points.length - 1; i < points.length; j = i++) {
+        const xi = points[i][0], yi = points[i][1];
+        const xj = points[j][0], yj = points[j][1];
+        const intersect = ((yi > y) !== (yj > y)) && (x < (xj - xi) * (y - yi) / (yj - yi) + xi);
+        if (intersect) inside = !inside;
+    }
+    return inside;
+}
+
+/**
+ * Return the id of the room whose outline polygon contains the given point,
+ * or undefined. Uses the same decoded getMapInfo_V2 `info` array as buildRoomsSvg,
+ * so the current room can be derived purely from geometry (needed on models that
+ * do not report a usable currentSpotAreaID).
+ * @param {Array} mapData
+ * @param {number} x
+ * @param {number} y
+ * @returns {(string|undefined)}
+ */
+function roomAtPoint(mapData, x, y) {
+    if (!Array.isArray(mapData)) return undefined;
+    const px = Number(x), py = Number(y);
+    if (!Number.isFinite(px) || !Number.isFinite(py)) return undefined;
+    let layer = mapData.find((s) => Array.isArray(s) && String(s[0]) === '2');
+    if (!layer) layer = mapData.find((s) => Array.isArray(s) && s.length > 1);
+    if (!layer) return undefined;
+    for (let i = 1; i < layer.length; i++) {
+        const p = parsePolygon(layer[i]);
+        if (p.points.length >= 3 && pointInPolygon(px, py, p.points)) {
+            return p.room;
+        }
+    }
+    return undefined;
+}
+
 module.exports.buildRoomsSvg = buildRoomsSvg;
+module.exports.roomAtPoint = roomAtPoint;

--- a/library/mapImageV2.js
+++ b/library/mapImageV2.js
@@ -112,7 +112,10 @@ function buildRoomsSvg(mapData, options = {}) {
     const ty = (y) => Math.round((maxY - y) * scale * 10) / 10;
 
     const parts = [];
-    parts.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + vw + ' ' + vh + '" width="' + vw + '" height="' + vh + '" style="background:' + background + ';border-radius:8px">');
+    // Expose the world->pixel transform so external overlays (e.g. a live
+    // robot dot in a dashboard) can place points without re-decoding the map:
+    //   pixelX = (worldX - minX) * scale ; pixelY = (maxY - worldY) * scale
+    parts.push('<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 ' + vw + ' ' + vh + '" width="' + vw + '" height="' + vh + '" data-minx="' + minX + '" data-maxy="' + maxY + '" data-scale="' + scale + '" style="background:' + background + ';border-radius:8px">');
     polys.forEach((p, idx) => {
         const d = 'M ' + p.points.map(([x, y]) => tx(x) + ',' + ty(y)).join(' L ') + ' Z';
         const col = PALETTE[idx % PALETTE.length];

--- a/library/mapImageV2.js
+++ b/library/mapImageV2.js
@@ -30,9 +30,40 @@ function parsePolygon(polyString) {
 }
 
 /**
+ * Normalize the `highlight` option into a Set of room-id strings.
+ * Accepts a single id, a comma-separated string or an array.
+ * @param {(string|number|Array)} highlight
+ * @returns {Set<string>}
+ */
+function toHighlightSet(highlight) {
+    const set = new Set();
+    if (highlight === undefined || highlight === null) return set;
+    const add = (v) => {
+        if (v === undefined || v === null) return;
+        const s = String(v).trim();
+        if (s !== '') set.add(s);
+    };
+    if (Array.isArray(highlight)) highlight.forEach(add);
+    else String(highlight).split(',').forEach(add);
+    return set;
+}
+
+function num(v) {
+    if (v === undefined || v === null || v === '') return null;
+    const n = Number(v);
+    return Number.isFinite(n) ? n : null;
+}
+
+/**
  * Build an SVG floor plan from the decoded getMapInfo_V2 `info` array.
  * @param {Array} mapData
- * @param {Object} [options] - {names, width, background, highlight}
+ * @param {Object} [options] - {names, width, background, highlight, robotPos, chargePos}
+ *   - names      {Object}          map of roomId -> display name
+ *   - width      {number}          target width in px (default 1000)
+ *   - background {string}          SVG background colour
+ *   - highlight  {string|number|Array} room id(s) to emphasise (e.g. room being cleaned)
+ *   - robotPos   {Object}          current robot position {x, y, a} (mm), draws a robot marker
+ *   - chargePos  {Object}          charging dock position {x, y} (mm), draws a base marker
  * @returns {string|null}
  */
 function buildRoomsSvg(mapData, options = {}) {
@@ -40,7 +71,14 @@ function buildRoomsSvg(mapData, options = {}) {
     const names = options.names || {};
     const targetWidth = options.width || 1000;
     const background = options.background || '#0b0b0b';
-    const highlight = options.highlight;
+    const hiSet = toHighlightSet(options.highlight);
+
+    const robotPos = options.robotPos && num(options.robotPos.x) !== null && num(options.robotPos.y) !== null
+        ? {x: num(options.robotPos.x), y: num(options.robotPos.y), a: num(options.robotPos.a)}
+        : null;
+    const chargePos = options.chargePos && num(options.chargePos.x) !== null && num(options.chargePos.y) !== null
+        ? {x: num(options.chargePos.x), y: num(options.chargePos.y)}
+        : null;
 
     let layer = mapData.find((s) => Array.isArray(s) && String(s[0]) === '2');
     if (!layer) layer = mapData.find((s) => Array.isArray(s) && s.length > 1);
@@ -58,6 +96,12 @@ function buildRoomsSvg(mapData, options = {}) {
         if (x < minX) minX = x; if (x > maxX) maxX = x;
         if (y < minY) minY = y; if (y > maxY) maxY = y;
     }
+    // make sure the robot / dock markers stay inside the viewBox
+    for (const m of [robotPos, chargePos]) {
+        if (!m) continue;
+        if (m.x < minX) minX = m.x; if (m.x > maxX) maxX = m.x;
+        if (m.y < minY) minY = m.y; if (m.y > maxY) maxY = m.y;
+    }
     const pad = 400;
     minX -= pad; maxX += pad; minY -= pad; maxY += pad;
     const w = maxX - minX, h = maxY - minY;
@@ -72,10 +116,11 @@ function buildRoomsSvg(mapData, options = {}) {
     polys.forEach((p, idx) => {
         const d = 'M ' + p.points.map(([x, y]) => tx(x) + ',' + ty(y)).join(' L ') + ' Z';
         const col = PALETTE[idx % PALETTE.length];
-        const isHi = highlight !== undefined && String(highlight) === String(p.room);
+        const isHi = hiSet.has(String(p.room));
         const fillOpacity = isHi ? 0.85 : 0.5;
         const strokeW = isHi ? 4 : 2.5;
-        parts.push('<path d="' + d + '" fill="' + col + '" fill-opacity="' + fillOpacity + '" stroke="' + col + '" stroke-width="' + strokeW + '"/>');
+        const stroke = isHi ? '#ffffff' : col;
+        parts.push('<path d="' + d + '" fill="' + col + '" fill-opacity="' + fillOpacity + '" stroke="' + stroke + '" stroke-width="' + strokeW + '"/>');
         let cx = 0, cy = 0;
         for (const [x, y] of p.points) { cx += tx(x); cy += ty(y); }
         cx = Math.round(cx / p.points.length);
@@ -83,6 +128,34 @@ function buildRoomsSvg(mapData, options = {}) {
         const label = names[p.room] || p.room;
         parts.push('<text x="' + cx + '" y="' + cy + '" fill="#fff" font-size="17" font-weight="bold" font-family="sans-serif" text-anchor="middle" style="paint-order:stroke;stroke:#000;stroke-width:3px">' + label + '</text>');
     });
+
+    // charging dock marker (drawn under the robot)
+    if (chargePos) {
+        const bx = tx(chargePos.x), by = ty(chargePos.y);
+        parts.push('<g transform="translate(' + bx + ',' + by + ')">');
+        parts.push('<rect x="-11" y="-11" width="22" height="22" rx="4" fill="#00c853" stroke="#ffffff" stroke-width="2.5"/>');
+        // little house glyph
+        parts.push('<path d="M -6,2 L 0,-5 L 6,2 M -4,2 L -4,6 L 4,6 L 4,2" fill="none" stroke="#ffffff" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>');
+        parts.push('</g>');
+    }
+
+    // robot marker with heading indicator
+    if (robotPos) {
+        const rx = tx(robotPos.x), ry = ty(robotPos.y);
+        parts.push('<g transform="translate(' + rx + ',' + ry + ')">');
+        if (robotPos.a !== null) {
+            // heading: world-space endpoint transformed so the y-flip is handled by ty()
+            const Lmm = 26 / scale;
+            const rad = robotPos.a * Math.PI / 180;
+            const hx = tx(robotPos.x + Lmm * Math.cos(rad)) - rx;
+            const hy = ty(robotPos.y + Lmm * Math.sin(rad)) - ry;
+            parts.push('<line x1="0" y1="0" x2="' + hx + '" y2="' + hy + '" stroke="#ffffff" stroke-width="3" stroke-linecap="round"/>');
+        }
+        parts.push('<circle cx="0" cy="0" r="13" fill="#2979ff" stroke="#ffffff" stroke-width="3"/>');
+        parts.push('<circle cx="0" cy="0" r="4" fill="#ffffff"/>');
+        parts.push('</g>');
+    }
+
     parts.push('</svg>');
     return parts.join('\n');
 }

--- a/library/mapTemplate.js
+++ b/library/mapTemplate.js
@@ -420,8 +420,19 @@ class EcovacsMapImage extends EcovacsMapImageBase {
 // converts the compressed data retrieved from ecovacs API into int array containing the map pixels
 // thanks to https://gitlab.com/michael.becker/vacuumclean/-/blob/master/deebot/deebot-core/README.md#map-details
 async function mapPieceToIntArray(pieceValue) {
-    const fixArray = new Int8Array([0, 0, 0, 0]);
     let buff = Buffer.from(pieceValue, 'base64');
+    // Newer models (e.g. DEEBOT T80S OMNI) send map data as Zstandard (magic 28 b5 2f fd)
+    // instead of LZMA. Detect the format and decompress accordingly.
+    if (buff.length >= 4 && buff[0] === 0x28 && buff[1] === 0xb5 && buff[2] === 0x2f && buff[3] === 0xfd) {
+        const fzstd = require('fzstd');
+        const decompressed = Buffer.from(fzstd.decompress(new Uint8Array(buff)));
+        // Subsets and boundaries are JSON/text; map image pieces are binary
+        if (decompressed.length && (decompressed[0] === 0x5b || decompressed[0] === 0x7b)) {
+            return decompressed.toString('utf8');
+        }
+        return [...new Int8Array(decompressed.buffer, decompressed.byteOffset, decompressed.length)];
+    }
+    const fixArray = new Int8Array([0, 0, 0, 0]);
     let int8Array = new Int8Array(buff.buffer, buff.byteOffset, buff.length);
     //fix 9 byte header to 13 bytes for lzma decompression
     let correctedArray = [...int8Array.slice(0, 9), ...fixArray, ...int8Array.slice(9)];

--- a/library/models.js
+++ b/library/models.js
@@ -685,6 +685,10 @@ exports.KnownDevices = {
         "yiko": true,
         "type": "X2"
     },
+    "rzwv5p": {
+        "name": "DEEBOT T80S OMNI",
+        "deviceClassLink": "e6ofmn"
+    },
     "lf3bn4": {
         "name": "DEEBOT X2",
         "deviceClassLink": "e6ofmn"

--- a/library/models.js
+++ b/library/models.js
@@ -1271,15 +1271,24 @@ exports.KnownDevices = {
     },
     "02qwum": {
         "name": "DEEBOT T80 OMNI",
-        "deviceClassLink": "p1jij8"
+        "deviceClassLink": "p1jij8",
+        "usesFreeClean": true
     },
     "9eamof": {
         "name": "DEEBOT T80 OMNI",
-        "deviceClassLink": "p1jij8"
+        "deviceClassLink": "p1jij8",
+        "usesFreeClean": true
     },
+    "jjg8ne": {
+        "name": "DEEBOT T50 Pro Omni Gen3",
+        "deviceClassLink": "p1jij8",
+        "usesFreeClean": true
+    },
+
     "k8qkc7": {
         "name": "DEEBOT T80 OMNI",
-        "deviceClassLink": "p1jij8"
+        "deviceClassLink": "p1jij8",
+        "usesFreeClean": true
     },
     "626v6g": {
         "name": "DEEBOT TEO+",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "smart home",
     "home automation"
   ],
-  "author": "Sascha Hölzel",
+  "author": "Sascha H\u00f6lzel",
   "license": "GPL-3.0",
   "repository": {
     "type": "git",
@@ -37,7 +37,8 @@
     "@xmldom/xmldom": "0.9.10",
     "lzma": "2.3.2",
     "uniqid": "5.4.0",
-    "chalk": "4.1.2"
+    "chalk": "4.1.2",
+    "fzstd": "^0.1.1"
   },
   "optionalDependencies": {
     "canvas": "2.10.2"


### PR DESCRIPTION
## Add DEEBOT T80S OMNI support (+ generic fixes for newer V2 models)

This PR adds support for the **DEEBOT T80S OMNI** (`deviceClass rzwv5p`) and, along the way, fixes several things that affect other newer (V2) models too. Tested end‑to‑end on a real T80S OMNI.

### Model
- Add `rzwv5p` → `deviceClassLink: e6ofmn` in `library/models.js` (resolves to the X2 capability set).
- Add `usesFreeClean` for models that ignore `spotArea_V2` and need `FreeClean` (T80 OMNI `9eamof`/`02qwum`/`k8qkc7`, T50 Pro Gen3 `jjg8ne`).

### Map data (Zstandard)
- `mapTemplate.js::mapPieceToIntArray` now auto‑detects the Zstandard magic (`28 b5 2f fd`) and decompresses with **fzstd** (pure JS), falling back to LZMA. Newer models deliver map pieces, spot‑area subsets and the vector map as zstd. Fixes the `-2 "corrupted input"` errors.

### Spot areas (V2)
- Route `GetSpotAreas` to the V2 command for V2 devices; `handleMapSet_V2` builds `EcovacsMapSpotAreas`/`EcovacsMapSpotAreaInfo`; the `MapSet_V2` case emits `MapSpotAreas`/`MapSpotAreaInfo` so the adapter creates the per‑room states.
- SpotArea cleaning uses `FreeClean` when `isModelTypeX2()` or `usesFreeClean` is set.

### Vector map image (SVG)
- Newer models no longer send the pixel map; they deliver a **vector map** via `getMapInfo_V2` (`.info` = base64+zstd, `[layerType, "roomId;x,y;…"]`). New `library/mapImageV2.js` renders it to an SVG floor plan (`buildRoomsSvg`) with room names.
- Optional **robot + charging‑dock markers** (with heading) and **cleaning‑room highlight** overlays.
- The root `<svg>` exposes the world→pixel transform as `data-minx`/`data-maxy`/`data-scale` so external dashboards can place a live robot dot without re‑decoding the map.
- `roomAtPoint()` (point‑in‑polygon) derives the current room purely from geometry — needed on models that never report a usable `currentSpotAreaID`.

### Status handling for newer models
- Handle **`CleanInfo_V2`** (same payload as `CleanInfo`) so `deviceStatus`/clean status update on models polled with `GetCleanState_V2`.
- Some models (e.g. T80S OMNI) keep `CleanInfo` `state:'idle'` even while cleaning; the working state is in the **`Stats`** message instead (empty `stopReason` = clean in progress). `handleStats` now derives the clean state from `stopReason` and forwards it as a `CleanReport`.
- Do not emit `WaterLevel` when the value is `undefined` (roller‑mop models) — stops a warning loop.

### Live overlay hook
- `buildLiveMapImageV2()` re‑renders the map SVG (rooms from cache + live robot/dock + highlight) on position pushes when `createMapImageOnPositionChange` is set — no extra cloud request (positions arrive via MQTT push; the map geometry is only fetched on map load).

### Notes
- `canvas` remains an optional dependency; the vector SVG path needs no native build.
- Companion adapter PRs: mrbungle64/ioBroker.ecovacs-deebot#843 (model entry) and #845 (store the vector SVG).
