### PR TITLE
Render getMapInfo_V2 vector map to PNG (T80/T80S/X8 OMNI)

### DIFF
--- a/library/managers/mapManager.js
+++ b/library/managers/mapManager.js
@@ -3,6 +3,7 @@
 const tools = require('../tools');
 const map = require('../mapInfo');
 const mapTemplate = require('../mapTemplate');
+const vectorMap = require('../render/vectorMap');
 const dictionary = require('../dictionary');
 const VacBotCommand = require('../command');
 const constants = require('../constants');
@@ -383,18 +384,37 @@ class MapManager {
      * Handle the payload of the 'MapInfo_V2' response/message
      * @param {Object} payload
      */
-    handleMapInfoV2(payload) {
+    async handleMapInfoV2(payload) {
         this.currentMapMID = payload['mid'];
-        tools.envLogNotice(`mid: ${this.currentMapMID}`);
-        tools.envLogNotice(`batid: ${payload['batid']}`);
-        tools.envLogNotice(`serial: ${payload['serial']}`);
-        tools.envLogNotice(`index: ${payload['index']}`);
-        tools.envLogNotice(`type: ${payload['type']}`);
-        tools.envLogNotice(`outlineVer: ${payload['outlineVer']}`);
-        tools.envLogNotice(`info: ${payload['info']}`);
-        tools.envLogNotice(`infoSize: ${payload['infoSize']}`);
-        tools.envLogNotice(`using: ${payload['using']}`);
-        tools.envLogNotice(`outlineCpmplete: ${payload['outlineCpmplete']}`); // The typo in 'Cpmplete' is intended
+        tools.envLogNotice(`[MapManager] MapInfo_V2 mid: ${this.currentMapMID} type: ${payload['type']} infoSize: ${payload['infoSize']}`);
+        // Newer devices (T80/T80S/X8 OMNI ...) deliver the active map as a vector
+        // floor plan in the base64 + Zstandard `info` field, not as raster pieces.
+        // Decode it and render a PNG so consumers get a map image via 'MapImage'.
+        if (!payload['info']) {
+            return;
+        }
+        try {
+            const decoded = await mapTemplate.decompressToString(payload['info']);
+            if (!decoded) {
+                // e.g. zstd unsupported on this Node runtime (< 22.15)
+                tools.envLogWarn('[MapManager] Could not decode MapInfo_V2 info payload');
+                return;
+            }
+            const vector = JSON.parse(decoded);
+            const dataURL = vectorMap.renderVectorMapPNG(vector, {
+                deebotPosition: this.bot.deebotPosition,
+                chargePosition: this.bot.chargePosition
+            });
+            if (!dataURL) {
+                tools.envLogInfo('[MapManager] MapInfo_V2 vector produced no renderable geometry');
+                return;
+            }
+            this.mapImageV2 = dataURL;
+            this.bot.ecovacs.emit('MapImageV2', { mapID: this.currentMapMID, mapBase64PNG: dataURL });
+            this.bot.ecovacs.emit('MapImage', dataURL);
+        } catch (e) {
+            tools.envLogError(`[MapManager] Error rendering MapInfo_V2 map: ${e.message}`);
+        }
     }
 
     /**

--- a/library/render/vectorMap.js
+++ b/library/render/vectorMap.js
@@ -1,0 +1,182 @@
+'use strict';
+
+/**
+ * Renders the *vector* floor plan delivered by `getMapInfo_V2` into a PNG data
+ * URL, using the same pure-JS primitives as the piece-based map renderer
+ * (no native `canvas` dependency).
+ *
+ * Newer devices (e.g. DEEBOT T80/T80S/X8 OMNI) do not stream a raster map via
+ * the GetMajorMap/GetMinorMap piece flow. Instead `getMapInfo_V2` returns an
+ * `info` payload (base64 + Zstandard) that decodes to a JSON array of layers:
+ *
+ *   [ [layerType, "roomId;x,y[,flag];x,y;..."], ... ]
+ *
+ * Layer types observed: "1" = walls, "2" = room outline (roomId = mssid),
+ * "6" = reachable area. Coordinates are in map/world units.
+ *
+ * @module render/vectorMap
+ */
+
+const { FrameBuffer } = require('./framebuffer');
+const shapes = require('./shapes');
+const { encodePNGDataURL } = require('./png');
+
+// Distinct fill colours cycled per room (RGB triples).
+const ROOM_COLORS = [
+    [76, 175, 80], [41, 182, 246], [255, 179, 0], [239, 83, 80],
+    [126, 87, 194], [38, 166, 154], [236, 64, 122], [141, 110, 99],
+    [66, 165, 245], [156, 204, 101], [255, 112, 67], [92, 107, 192]
+];
+const WALL_COLOR = [230, 230, 230];
+const BG_COLOR = [11, 11, 11];
+const ROBOT_COLOR = [33, 150, 243];
+const CHARGER_COLOR = [76, 175, 80];
+
+/**
+ * Parses a layer coordinate string `"roomId;x,y[,flag];..."`.
+ * @param {string} str
+ * @returns {{id: string, points: number[][]}}
+ */
+function parseLayer(str) {
+    const parts = String(str).split(';');
+    const id = parts.shift();
+    const points = [];
+    for (const part of parts) {
+        if (!part) {
+            continue;
+        }
+        const xy = part.split(',');
+        const x = parseFloat(xy[0]);
+        const y = parseFloat(xy[1]);
+        if (Number.isFinite(x) && Number.isFinite(y)) {
+            points.push([x, y]);
+        }
+    }
+    return { id, points };
+}
+
+/**
+ * Normalises the `highlight` option to a Set of room-id strings.
+ * @param {string|number|Array<string|number>} highlight
+ * @returns {Set<string>}
+ */
+function toHighlightSet(highlight) {
+    if (highlight === undefined || highlight === null || highlight === '') {
+        return new Set();
+    }
+    const list = Array.isArray(highlight) ? highlight : String(highlight).split(',');
+    return new Set(list.map((v) => String(v).trim()).filter((v) => v.length));
+}
+
+/**
+ * Splits the decoded vector into rooms (type 2) and walls (type 1).
+ * @param {Array} vector
+ * @returns {{rooms: Array, walls: Array}}
+ */
+function classifyLayers(vector) {
+    const rooms = [];
+    const walls = [];
+    if (!Array.isArray(vector)) {
+        return { rooms, walls };
+    }
+    for (const layer of vector) {
+        if (!Array.isArray(layer) || layer.length < 2) {
+            continue;
+        }
+        const type = String(layer[0]);
+        const parsed = parseLayer(layer[1]);
+        if (type === '2') {
+            rooms.push(parsed);
+        } else if (type === '1') {
+            walls.push(parsed);
+        }
+    }
+    return { rooms, walls };
+}
+
+/**
+ * Renders the decoded `getMapInfo_V2` vector to a PNG data URL.
+ *
+ * @param {Array} vector - decoded `info` array `[[type, "id;x,y;..."], ...]`
+ * @param {Object} [opts]
+ * @param {number} [opts.width=1000] - output width in pixels (height derived)
+ * @param {number} [opts.padding=20] - border padding in pixels
+ * @param {{x:number,y:number}} [opts.deebotPosition] - robot marker (world units)
+ * @param {{x:number,y:number}} [opts.chargePosition] - charger marker (world units)
+ * @param {string|number|Array} [opts.highlight] - room id(s) to emphasise
+ * @returns {string|null} PNG data URL, or null when nothing renderable
+ */
+function renderVectorMapPNG(vector, opts = {}) {
+    const width = opts.width || 1000;
+    const padding = opts.padding !== undefined ? opts.padding : 20;
+    const highlight = toHighlightSet(opts.highlight);
+
+    const { rooms, walls } = classifyLayers(vector);
+    if (!rooms.length && !walls.length) {
+        return null;
+    }
+
+    // Bounding box over every point.
+    let minX = Infinity;
+    let minY = Infinity;
+    let maxX = -Infinity;
+    let maxY = -Infinity;
+    for (const group of [rooms, walls]) {
+        for (const layer of group) {
+            for (const [x, y] of layer.points) {
+                if (x < minX) { minX = x; }
+                if (x > maxX) { maxX = x; }
+                if (y < minY) { minY = y; }
+                if (y > maxY) { maxY = y; }
+            }
+        }
+    }
+    if (!Number.isFinite(minX)) {
+        return null;
+    }
+
+    const worldW = (maxX - minX) || 1;
+    const worldH = (maxY - minY) || 1;
+    const scale = (width - padding * 2) / worldW;
+    const height = Math.round(worldH * scale + padding * 2);
+
+    // World -> pixel (Y is flipped so the map is not upside down).
+    const tx = (x) => padding + (x - minX) * scale;
+    const ty = (y) => padding + (maxY - y) * scale;
+
+    const fb = new FrameBuffer(width, height);
+    fb.fillRect(0, 0, width, height, BG_COLOR[0], BG_COLOR[1], BG_COLOR[2], 255);
+
+    rooms.forEach((room, index) => {
+        if (room.points.length < 3) {
+            return;
+        }
+        const color = ROOM_COLORS[index % ROOM_COLORS.length];
+        const pts = room.points.map(([x, y]) => [tx(x), ty(y)]);
+        const emphasised = highlight.has(String(room.id));
+        shapes.fillPolygon(fb, pts, color, emphasised ? 216 : 120);
+        shapes.strokePolyline(fb, pts, color, { closed: true, width: 2 });
+    });
+
+    walls.forEach((wall) => {
+        if (wall.points.length < 2) {
+            return;
+        }
+        const pts = wall.points.map(([x, y]) => [tx(x), ty(y)]);
+        shapes.strokePolyline(fb, pts, WALL_COLOR, { width: 2 });
+    });
+
+    const marker = (pos, color, radius) => {
+        if (pos && Number.isFinite(pos.x) && Number.isFinite(pos.y)) {
+            shapes.fillCircle(fb, tx(pos.x), ty(pos.y), radius, color, 255);
+        }
+    };
+    marker(opts.chargePosition, CHARGER_COLOR, 8);
+    marker(opts.deebotPosition, ROBOT_COLOR, 9);
+
+    return encodePNGDataURL(fb);
+}
+
+module.exports.renderVectorMapPNG = renderVectorMapPNG;
+module.exports.parseLayer = parseLayer;
+module.exports.classifyLayers = classifyLayers;


### PR DESCRIPTION
### Summary
On `1.0.0-alpha.0`, `MapManager.handleMapInfoV2` only logs the payload, so the newer OMNI devices that deliver the active map as a **vector floor plan** via `getMapInfo_V2` (geometry in the base64 + Zstandard `info` field) never produce a map image. This implements the rendering for them.

- Decode `info` with `mapTemplate.decompressToString` (already zstd/LZMA aware, no new deps).
- Parse the `[[type, "id;x,y;..."], ...]` layers and render room outlines (type `2`) and walls (type `1`) to a PNG **data URL** using the existing pure-JS `render/` pipeline (`FrameBuffer` + `shapes`).
- Draw robot/charger markers from `bot.deebotPosition` / `bot.chargePosition`.
- Emit as `MapImage` (data URL, matching the existing raster-map output contract) and `MapImageV2` (`{ mapID, mapBase64PNG }`).

New module: `library/render/vectorMap.js`. Non-V2 devices are unaffected (only reached from `handleMapInfoV2` when `info` is present).

### Tested
End to end with a real zstd `info` sample (compressed via Node's `zlib`, magic `28 b5 2f fd`): `decompressToString` → `JSON.parse` → renderer → valid PNG. Rooms, walls and markers render correctly (Y-flipped, per-room colours, optional highlight). The `rzwv5p` (DEEBOT T80S OMNI) entry already exists in `models.js` on this branch, so this completes the map side for that generation.

### Open questions
- **Room name labels** are omitted because the framebuffer has no text rasteriser. Would you like labels (small bitmap font, or an SVG variant), or is the coloured-rooms PNG enough with names kept in the map data object for consumers?
- `smartType` for `rzwv5p` is `MQ_AP` in `models.js` but `BLAP2` in `productIotMap.json` (like the T80 OMNI siblings `02qwum`/`9eamof`/...). Intended?

### Not in this PR (follow-ups)
- Cleaning-room highlight (point-in-polygon from robot position + cleaning state via `Stats`).
- Adapter-side alignment to the `MapImage` / `MapImageV2` PNG output.
